### PR TITLE
Add operator and k8s orchestration to chart

### DIFF
--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 0.2.0
+version: 0.3.0

--- a/charts/lunar/templates/NOTES.txt
+++ b/charts/lunar/templates/NOTES.txt
@@ -28,6 +28,9 @@ Elastic (when hub.logging.elastic.url is set):
 Badges (when badges.enabled is true):
   {{ printf "%-30s" .Values.badges.secret.name }}  key: {{ .Values.badges.secret.key }}
 {{- end }}
+
+Operator:
+  Uses the same DB and auth secrets as the Hub (listed above).
 {{- if .Values.grafana.enabled }}
 
 Grafana (when grafana.enabled is true):

--- a/charts/lunar/templates/_helpers.tpl
+++ b/charts/lunar/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Namespace where snippet pods run. Defaults to the release namespace.
+*/}}
+{{- define "lunar.snippetNamespace" -}}
+{{- .Values.operator.snippetNamespace | default .Release.Namespace }}
+{{- end }}

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -131,7 +131,9 @@ spec:
               value: {{ .logging.elastic.flushInterval | quote }}
             {{- end }}
             - name: HUB_LOGS_AWS_BUCKET
-              value: {{ .s3.bucketName | quote }}
+              value: {{ .s3.logsBucket | quote }}
+            - name: HUB_RESOURCES_AWS_BUCKET
+              value: {{ .s3.resourcesBucket | quote }}
             - name: HUB_LOGS_AWS_URL_TTL
               value: {{ .s3.urlExpirationMinutes | quote }}
             - name: HUB_K8S_EXECUTION_ENABLED

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -134,6 +134,8 @@ spec:
               value: {{ .s3.bucketName | quote }}
             - name: HUB_LOGS_AWS_URL_TTL
               value: {{ .s3.urlExpirationMinutes | quote }}
+            - name: HUB_K8S_EXECUTION_ENABLED
+              value: "true"
             {{- if $.Values.badges.enabled }}
             - name: HUB_BADGES_PORT
               value: {{ $.Values.badges.service.port | quote }}
@@ -185,13 +187,26 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.hub.volumeMounts }}
+          {{- if or .Values.hub.persistence.enabled .Values.hub.volumeMounts }}
           volumeMounts:
+            {{- if .Values.hub.persistence.enabled }}
+            - name: hub-data
+              mountPath: /var/lib/lunar
+            {{- end }}
+            {{- with .Values.hub.volumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
-      {{- with .Values.hub.volumes }}
+      {{- if or .Values.hub.persistence.enabled .Values.hub.volumes }}
       volumes:
+        {{- if .Values.hub.persistence.enabled }}
+        - name: hub-data
+          persistentVolumeClaim:
+            claimName: {{ include "lunar.fullname" . }}-hub-data
+        {{- end }}
+        {{- with .Values.hub.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.hub.nodeSelector }}
       nodeSelector:

--- a/charts/lunar/templates/hub-pvc.yaml
+++ b/charts/lunar/templates/hub-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.hub.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "lunar.fullname" . }}-hub-data
+  labels:
+    {{- include "lunar.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hub
+spec:
+  accessModes:
+    {{- toYaml .Values.hub.persistence.accessModes | nindent 4 }}
+  {{- if .Values.hub.persistence.storageClass }}
+  storageClassName: {{ .Values.hub.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.hub.persistence.size }}
+{{- end }}

--- a/charts/lunar/templates/operator-deployment.yaml
+++ b/charts/lunar/templates/operator-deployment.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lunar.fullname" . }}-operator
+  labels:
+    {{- include "lunar.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "lunar.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: operator
+  template:
+    metadata:
+      {{- with .Values.operator.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "lunar.labels" . | nindent 8 }}
+        app.kubernetes.io/component: operator
+        {{- with .Values.operator.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "lunar.fullname" . }}-operator
+      {{- with .Values.operator.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: operator
+          {{- with .Values.operator.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.operator.healthPort }}
+              name: health
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+          env:
+            - name: OPERATOR_DB_NAME
+              value: {{ .Values.hub.db.name | quote }}
+            - name: OPERATOR_DB_HOST
+              value: {{ .Values.hub.db.host | quote }}
+            - name: OPERATOR_DB_PORT
+              value: {{ .Values.hub.db.port | quote }}
+            - name: OPERATOR_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.hub.db.user.secretName }}
+                  key: {{ .Values.hub.db.user.secretKey }}
+            - name: OPERATOR_DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.hub.db.pass.secretName }}
+                  key: {{ .Values.hub.db.pass.secretKey }}
+            - name: OPERATOR_NAMESPACE
+              value: {{ include "lunar.snippetNamespace" . | quote }}
+            - name: OPERATOR_MAX_CONCURRENT
+              value: {{ .Values.operator.maxConcurrent | quote }}
+            - name: OPERATOR_HEALTH_PORT
+              value: {{ .Values.operator.healthPort | quote }}
+            - name: OPERATOR_LOG_LEVEL
+              value: {{ .Values.operator.logging.level | quote }}
+            - name: OPERATOR_LOG_FORMAT
+              value: {{ .Values.operator.logging.format | quote }}
+            - name: OPERATOR_INIT_IMAGE
+              value: "{{ .Values.operator.initImage.repository }}:{{ .Values.operator.initImage.tag | default .Chart.AppVersion }}"
+            - name: OPERATOR_SIDECAR_IMAGE
+              value: "{{ .Values.operator.sidecarImage.repository }}:{{ .Values.operator.sidecarImage.tag | default .Chart.AppVersion }}"
+            - name: OPERATOR_HUB_HOST
+              value: {{ include "lunar.fullname" . }}-hub
+            - name: OPERATOR_HUB_GRPC_PORT
+              value: {{ .Values.hub.service.ports.server | quote }}
+            - name: OPERATOR_HUB_HTTP_PORT
+              value: {{ .Values.hub.service.ports.http | quote }}
+            - name: OPERATOR_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.hub.auth.secretName }}
+                  key: {{ .Values.hub.auth.secretKey }}
+            - name: OPERATOR_POD_SERVICE_ACCOUNT
+              value: {{ include "lunar.fullname" . }}-snippet-pod
+            {{- with .Values.operator.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.operator.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/lunar/templates/operator-rbac.yaml
+++ b/charts/lunar/templates/operator-rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "lunar.fullname" . }}-operator
+  namespace: {{ include "lunar.snippetNamespace" . }}
+  labels:
+    {{- include "lunar.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "lunar.fullname" . }}-operator
+  namespace: {{ include "lunar.snippetNamespace" . }}
+  labels:
+    {{- include "lunar.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "lunar.fullname" . }}-operator
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "lunar.fullname" . }}-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/lunar/templates/operator-serviceaccount.yaml
+++ b/charts/lunar/templates/operator-serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lunar.fullname" . }}-operator
+  labels:
+    {{- include "lunar.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator

--- a/charts/lunar/templates/snippet-pod-rbac.yaml
+++ b/charts/lunar/templates/snippet-pod-rbac.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lunar.fullname" . }}-snippet-pod
+  namespace: {{ include "lunar.snippetNamespace" . }}
+  labels:
+    {{- include "lunar.labels" . | nindent 4 }}
+    app.kubernetes.io/component: snippet-pod
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "lunar.fullname" . }}-snippet-pod
+  namespace: {{ include "lunar.snippetNamespace" . }}
+  labels:
+    {{- include "lunar.labels" . | nindent 4 }}
+    app.kubernetes.io/component: snippet-pod
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "lunar.fullname" . }}-snippet-pod
+  namespace: {{ include "lunar.snippetNamespace" . }}
+  labels:
+    {{- include "lunar.labels" . | nindent 4 }}
+    app.kubernetes.io/component: snippet-pod
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "lunar.fullname" . }}-snippet-pod
+    namespace: {{ include "lunar.snippetNamespace" . }}
+roleRef:
+  kind: Role
+  name: {{ include "lunar.fullname" . }}-snippet-pod
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -45,7 +45,8 @@ hub:
     pollInterval: 1s
     numWorkers: 5
   s3:
-    bucketName: ""
+    logsBucket: ""
+    resourcesBucket: ""
     urlExpirationMinutes: 5m
   auth:
     secretName: "lunar-auth-token"

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -14,6 +14,7 @@ serviceAccount:
 
 hub:
   rootDir: /hub/
+
   db:
     user:
       secretName: "lunar-db"
@@ -70,6 +71,14 @@ hub:
         secretKey: "api-key"
       bufferSize: 100
       flushInterval: "5s"
+
+  persistence:
+    enabled: false
+    storageClass: ""
+    size: 10Gi
+    accessModes:
+      - ReadWriteOnce
+
   extraEnv: []
 
   image:
@@ -113,8 +122,44 @@ hub:
   podSecurityContext: {}
   securityContext: {}
   resources: {}
-  volumeMounts: {}
-  volumes: {}
+  volumeMounts: []
+  volumes: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+operator:
+  image:
+    repository: "earthly/lunar-snippet-operator"
+    pullPolicy: IfNotPresent
+    tag: "main"
+
+  initImage:
+    repository: "earthly/lunar-snippet-init"
+    pullPolicy: IfNotPresent
+    tag: "main"
+
+  sidecarImage:
+    repository: "earthly/lunar-snippet-sidecar"
+    pullPolicy: IfNotPresent
+    tag: "main"
+
+  # Namespace where snippet pods are created. Defaults to the release namespace.
+  # Set to a different namespace to isolate snippet workloads from infrastructure.
+  snippetNamespace: ""
+  maxConcurrent: 10
+  healthPort: 8081
+
+  logging:
+    level: "info"
+    format: "json"
+
+  extraEnv: []
+  resources: {}
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -155,8 +200,8 @@ badges:
   podSecurityContext: {}
   securityContext: {}
   resources: {}
-  volumeMounts: {}
-  volumes: {}
+  volumeMounts: []
+  volumes: []
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -201,8 +246,8 @@ grafana:
   podSecurityContext: {}
   securityContext: {}
   resources: {}
-  volumeMounts: {}
-  volumes: {}
+  volumeMounts: []
+  volumes: []
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -75,6 +75,7 @@ hub:
 
   persistence:
     enabled: false
+    # Leave empty to use the cluster default StorageClass.
     storageClass: ""
     size: 10Gi
     accessModes:

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -146,7 +146,7 @@ operator:
     tag: "main"
 
   # Namespace where snippet pods are created. Defaults to the release namespace.
-  # Set to a different namespace to isolate snippet workloads from infrastructure.
+  # If set, the namespace must already exist — the chart will not create it.
   snippetNamespace: ""
   maxConcurrent: 10
   healthPort: 8081


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Hub data persistence via PVC with conditional mounts; separate log and resources bucket settings; operator-enabled execution flag
  * Operator deployment, ServiceAccount and RBAC for in-cluster management
  * Snippet-pod support with configurable snippet namespace and required RBAC

* **Documentation**
  * NOTES updated to include Operator details and secret usage

* **Chores**
  * Chart version bumped to 0.3.0; values schema expanded for operator, persistence, topology, and volume declarations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->