### PR TITLE
add containerspec support

### DIFF
--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 0.4.0
+version: 0.4.1

--- a/charts/lunar/templates/operator-deployment.yaml
+++ b/charts/lunar/templates/operator-deployment.yaml
@@ -101,6 +101,10 @@ spec:
             - name: OPERATOR_IMAGE_PULL_SECRETS
               value: {{ range $i, $s := .Values.imagePullSecrets }}{{ if $i }},{{ end }}{{ $s.name }}{{ end }}
             {{- end }}
+            {{- if .Values.operator.snippetContainerSpec }}
+            - name: OPERATOR_SNIPPET_CONTAINER_SPEC
+              value: {{ .Values.operator.snippetContainerSpec | toJson | quote }}
+            {{- end }}
             {{- with .Values.operator.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/lunar/templates/operator-deployment.yaml
+++ b/charts/lunar/templates/operator-deployment.yaml
@@ -101,7 +101,7 @@ spec:
             - name: OPERATOR_IMAGE_PULL_SECRETS
               value: {{ range $i, $s := .Values.imagePullSecrets }}{{ if $i }},{{ end }}{{ $s.name }}{{ end }}
             {{- end }}
-            {{- if .Values.operator.snippetContainerSpec }}
+            {{- if not (eq (toJson .Values.operator.snippetContainerSpec) "{}") }}
             - name: OPERATOR_SNIPPET_CONTAINER_SPEC
               value: {{ .Values.operator.snippetContainerSpec | toJson | quote }}
             {{- end }}

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -156,6 +156,19 @@ operator:
     level: "info"
     format: "json"
 
+  # Base container spec for snippet pods. The operator overlays required fields
+  # (name, image, command, workingDir, volume mounts) on top — you control
+  # everything else: resources, env, envFrom, securityContext, etc.
+  # Example:
+  #   snippetContainerSpec:
+  #     resources:
+  #       requests:
+  #         cpu: "500m"
+  #         memory: "1Gi"
+  #     securityContext:
+  #       runAsNonRoot: true
+  snippetContainerSpec: {}
+
   extraEnv: []
   resources: {}
   podAnnotations: {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Helm chart version to 0.4.1.

* **New Features**
  * Added an optional operator configuration for snippet container specifications, enabling explicit control over container settings (resources, env, security context). When provided, this configuration is surfaced to the operator deployment and applied to snippet pods; it is ignored if left unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->