### PR TITLE
Add HUB_BADGES_SECURE to hub deployment template

### DIFF
--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 0.4.4
+version: 0.4.5

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 0.4.5
+version: 0.4.6

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -141,6 +141,8 @@ spec:
             {{- if $.Values.badges.enabled }}
             - name: HUB_BADGES_PORT
               value: {{ $.Values.badges.service.port | quote }}
+            - name: HUB_BADGES_SECURE
+              value: {{ $.Values.badges.secure | quote }}
             - name: HUB_BADGES_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -200,6 +200,9 @@ operator:
 
 badges:
   enabled: false
+  # The in-cluster badges sidecar listens on plain HTTP. Set to true only
+  # if the hub should reach the badges service over HTTPS.
+  secure: false
 
   extraEnv: []
 


### PR DESCRIPTION
## Summary
- Add `badges.secure` value (default: `false`) to `values.yaml`
- Wire it into the hub deployment template as `HUB_BADGES_SECURE` in the badges-enabled block
- Bump chart version to 0.4.5

The hub-deployment template sets `HUB_BADGES_HOST`, `HUB_BADGES_PORT`, and `HUB_BADGES_SECRET` when badges are enabled, but omits `HUB_BADGES_SECURE`. The Go config defaults to `true`, causing `http: server gave HTTP response to HTTPS client` errors since the in-cluster badges sidecar listens on plain HTTP (port 80).

This was previously worked around via `hub.extraEnv` in the lunar repo (earthly/lunar#1229). Once this chart version is released, those `extraEnv` entries can be removed.

## Test plan
- [ ] `helm template` renders `HUB_BADGES_SECURE: "false"` in the hub container env when `badges.enabled=true`
- [ ] Existing deployments continue to work (value defaults to `false`, matching current `extraEnv` workaround)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a badges "secure" toggle so the badges sidecar can be contacted over HTTPS (defaults to HTTP); deployments now honor this setting when badges are enabled.

* **Chores**
  * Chart version bumped to 0.4.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->