### PR TITLE
Add hub.publicBaseURL chart value for external URL config

### DIFF
--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 0.4.6
+version: 0.4.7

--- a/charts/lunar/templates/grafana-deployment.yaml
+++ b/charts/lunar/templates/grafana-deployment.yaml
@@ -61,6 +61,12 @@ spec:
               value: {{ $.Values.hub.db.name | quote }}
             - name: LUNAR_HUB_HOST
               value: {{ include "lunar.fullname" $ }}-hub
+            - name: LUNAR_HUB_BASE_URL
+              value: {{ ($.Values.hub.publicBaseURL | default (printf "http://%s-hub:%v" (include "lunar.fullname" $) $.Values.hub.service.ports.http)) | quote }}
+            {{- if $.Values.hub.publicBaseURL }}
+            - name: GF_SERVER_ROOT_URL
+              value: {{ $.Values.hub.publicBaseURL | quote }}
+            {{- end }}
             - name: LUNAR_HUB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/lunar/templates/grafana-deployment.yaml
+++ b/charts/lunar/templates/grafana-deployment.yaml
@@ -61,8 +61,8 @@ spec:
               value: {{ $.Values.hub.db.name | quote }}
             - name: LUNAR_HUB_HOST
               value: {{ include "lunar.fullname" $ }}-hub
-            - name: LUNAR_HUB_BASE_URL
-              value: {{ ($.Values.hub.publicBaseURL | default (printf "http://%s-hub:%v" (include "lunar.fullname" $) $.Values.hub.service.ports.http)) | quote }}
+            - name: LUNAR_HUB_HTTP_PORT
+              value: {{ $.Values.hub.service.ports.http | quote }}
             {{- if $.Values.hub.publicBaseURL }}
             - name: GF_SERVER_ROOT_URL
               value: {{ $.Values.hub.publicBaseURL | quote }}

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -140,6 +140,10 @@ spec:
               value: {{ .s3.resourcesBucket | quote }}
             - name: HUB_LOGS_AWS_URL_TTL
               value: {{ .s3.urlExpirationMinutes | quote }}
+            {{- if .publicBaseURL }}
+            - name: HUB_PUBLIC_BASE_URL
+              value: {{ .publicBaseURL | quote }}
+            {{- end }}
             - name: HUB_K8S_EXECUTION_ENABLED
               value: "true"
             {{- if $.Values.badges.enabled }}

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -13,6 +13,10 @@ serviceAccount:
   name: ""
 
 hub:
+  # External URL where the hub is reachable (e.g. https://cronos.demo.earthly.dev).
+  # Used by the hub for webhook callbacks and by Grafana for dashboard log links.
+  publicBaseURL: ""
+
   rootDir: /hub/
 
   db:


### PR DESCRIPTION
## Summary
- Add `hub.publicBaseURL` as a first-class chart value (defaults to empty)
- When set, the hub deployment gets `HUB_PUBLIC_BASE_URL` (for webhook callbacks) and Grafana gets `GF_SERVER_ROOT_URL` (for link sharing)
- Add `LUNAR_HUB_HTTP_PORT` to the Grafana deployment so the Infinity datasource can construct its base URL from `LUNAR_HUB_HOST` + port — all internal, no external routing for data fetching
- `publicBaseURL` is only used where external access is actually required (webhook callbacks, browser-facing link generation)

Companion to earthly/lunar#1243.

## Test plan
- [ ] `helm template` with `hub.publicBaseURL` set — verify `HUB_PUBLIC_BASE_URL` and `GF_SERVER_ROOT_URL` appear, and `LUNAR_HUB_HTTP_PORT` uses the chart port value
- [ ] `helm template` with `hub.publicBaseURL` empty — verify no `GF_SERVER_ROOT_URL` / `HUB_PUBLIC_BASE_URL`, and `LUNAR_HUB_HTTP_PORT` still present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional public hub base URL setting to enable webhook callbacks and external dashboard integrations.
  * When set, Grafana and the hub will use the public URL to generate correct external links and root URLs so dashboards and callbacks work from outside the cluster.

* **Chores**
  * Chart version updated to 0.4.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->