### PR TITLE
Set terminationGracePeriodSeconds for hub pod

### DIFF
--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 0.4.8
+version: 0.4.9

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "lunar.serviceAccountName" . }}
+      terminationGracePeriodSeconds: 60
       {{- with .Values.hub.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Summary
- Bump chart to `0.4.9`
- Set `terminationGracePeriodSeconds: 60` on the hub deployment to match the new 45s graceful shutdown timeout added in earthly/lunar#1270

## Test plan
- [ ] `helm template` renders correctly
- [ ] Deploy and verify hub pod spec shows `terminationGracePeriodSeconds: 60`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Chart version updated to 0.4.9
  * Hub pod shutdown grace period improved for better graceful termination during updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->