### PR TITLE
Add nginx kiosk sidecar to Grafana deployment

### DIFF
--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 0.4.9
+version: 0.4.10

--- a/charts/lunar/templates/grafana-deployment.yaml
+++ b/charts/lunar/templates/grafana-deployment.yaml
@@ -110,10 +110,22 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.grafana.volumes }}
+        - name: kiosk
+          image: nginx:1-alpine
+          ports:
+            - name: kiosk
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: kiosk-config
+              mountPath: /etc/nginx/conf.d
       volumes:
+        - name: kiosk-config
+          configMap:
+            name: {{ include "lunar.fullname" . }}-grafana-kiosk
+        {{- with .Values.grafana.volumes }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       {{- with .Values.grafana.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/lunar/templates/grafana-deployment.yaml
+++ b/charts/lunar/templates/grafana-deployment.yaml
@@ -119,6 +119,11 @@ spec:
           volumeMounts:
             - name: kiosk-config
               mountPath: /etc/nginx/conf.d
+      {{- range .Values.grafana.volumes }}
+      {{- if eq .name "kiosk-config" }}
+      {{- fail "Values.grafana.volumes contains reserved name 'kiosk-config'" }}
+      {{- end }}
+      {{- end }}
       volumes:
         - name: kiosk-config
           configMap:

--- a/charts/lunar/templates/grafana-kiosk-configmap.yaml
+++ b/charts/lunar/templates/grafana-kiosk-configmap.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.grafana.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "lunar.fullname" . }}-grafana-kiosk
+  labels:
+    {{- include "lunar.labels" . | nindent 4 }}
+data:
+  default.conf: |
+    # Inject ?kiosk into Grafana dashboard URLs to hide the default menu.
+    # Replicates the Caddy rewrite rules from the docker-compose setup.
+
+    map $args $has_kiosk {
+        "~(^|&)kiosk(=|&|$)"  1;
+        default                0;
+    }
+
+    map $is_args $kiosk_suffix {
+        "?"     "&kiosk";
+        default "?kiosk";
+    }
+
+    server {
+        listen 8080;
+
+        location = / {
+            if ($has_kiosk = 0) {
+                return 302 /$is_args$args$kiosk_suffix;
+            }
+            proxy_pass http://localhost:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+
+        location ~ ^/(d|dashboard)/ {
+            if ($has_kiosk = 0) {
+                return 302 $uri$is_args$args$kiosk_suffix;
+            }
+            proxy_pass http://localhost:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+
+        location / {
+            proxy_pass http://localhost:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+    }
+{{- end }}

--- a/charts/lunar/templates/grafana-service.yaml
+++ b/charts/lunar/templates/grafana-service.yaml
@@ -9,7 +9,7 @@ spec:
   type: {{ .Values.grafana.service.type }}
   ports:
     - port: {{ .Values.grafana.service.port }}
-      targetPort: http
+      targetPort: kiosk
       protocol: TCP
       name: grafana-ui
   selector:


### PR DESCRIPTION
## Summary
- Adds an nginx sidecar container to the Grafana pod that injects `?kiosk` into dashboard URLs, hiding Grafana's default menu for a more native look
- The docker-compose setup used Caddy rewrite rules for this; the EKS setup uses AWS ALB which can't manipulate query strings, so an in-pod nginx proxy fills the gap
- Traffic flow: ALB → Service :80 → nginx :8080 → Grafana :3000

## Changes
- **New** `grafana-kiosk-configmap.yaml` — nginx config with `map` directives to detect/append the kiosk param on `/`, `/d/*`, and `/dashboard/*` paths
- **Modified** `grafana-deployment.yaml` — adds `nginx:1-alpine` sidecar + ConfigMap volume
- **Modified** `grafana-service.yaml` — `targetPort` changed from `http` (3000) to `kiosk` (8080)

## Test plan
- [ ] Deploy to a demo tenant and verify dashboards load in kiosk mode (no top nav/sidebar)
- [ ] Verify direct dashboard links with existing query params get `&kiosk` appended correctly
- [ ] Verify API calls (`/api/*`) and static assets pass through without redirect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Grafana kiosk mode with automatic dashboard redirection and intelligent URL parameter handling to streamline display configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->