### PR TITLE
Per-snippet-type container specs and batch sizes for operator

### DIFF
--- a/charts/lunar/templates/operator-deployment.yaml
+++ b/charts/lunar/templates/operator-deployment.yaml
@@ -118,9 +118,29 @@ spec:
             - name: OPERATOR_IMAGE_PULL_SECRETS
               value: {{ range $i, $s := .Values.imagePullSecrets }}{{ if $i }},{{ end }}{{ $s.name }}{{ end }}
             {{- end }}
-            {{- if not (eq (toJson .Values.operator.snippetContainerSpec) "{}") }}
-            - name: OPERATOR_SNIPPET_CONTAINER_SPEC
-              value: {{ .Values.operator.snippetContainerSpec | toJson | quote }}
+            {{- if not (eq (toJson .Values.operator.snippetContainerSpecPolicy) "{}") }}
+            - name: OPERATOR_SNIPPET_CONTAINER_SPEC_POLICY
+              value: {{ .Values.operator.snippetContainerSpecPolicy | toJson | quote }}
+            {{- end }}
+            {{- if not (eq (toJson .Values.operator.snippetContainerSpecCollector) "{}") }}
+            - name: OPERATOR_SNIPPET_CONTAINER_SPEC_COLLECTOR
+              value: {{ .Values.operator.snippetContainerSpecCollector | toJson | quote }}
+            {{- end }}
+            {{- if not (eq (toJson .Values.operator.snippetContainerSpecCataloger) "{}") }}
+            - name: OPERATOR_SNIPPET_CONTAINER_SPEC_CATALOGER
+              value: {{ .Values.operator.snippetContainerSpecCataloger | toJson | quote }}
+            {{- end }}
+            {{- if gt (int .Values.operator.batchMaxCountPolicy) 0 }}
+            - name: OPERATOR_BATCH_MAX_COUNT_POLICY
+              value: {{ .Values.operator.batchMaxCountPolicy | quote }}
+            {{- end }}
+            {{- if gt (int .Values.operator.batchMaxCountCollector) 0 }}
+            - name: OPERATOR_BATCH_MAX_COUNT_COLLECTOR
+              value: {{ .Values.operator.batchMaxCountCollector | quote }}
+            {{- end }}
+            {{- if gt (int .Values.operator.batchMaxCountCataloger) 0 }}
+            - name: OPERATOR_BATCH_MAX_COUNT_CATALOGER
+              value: {{ .Values.operator.batchMaxCountCataloger | quote }}
             {{- end }}
             {{- if not (eq (toJson .Values.operator.snippetPodNodeSelector) "{}") }}
             - name: OPERATOR_SNIPPET_POD_NODE_SELECTOR

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -168,18 +168,40 @@ operator:
       bufferSize: 100
       flushInterval: "5s"
 
-  # Base container spec for snippet pods. The operator overlays required fields
-  # (name, image, command, workingDir, volume mounts) on top — you control
-  # everything else: resources, env, envFrom, securityContext, etc.
+  # Per-snippet-type base container spec. The operator overlays required
+  # fields (name, image, command, workingDir, volume mounts) on top — you
+  # control everything else: resources, env, envFrom, securityContext, etc.
+  #
+  # Types with no override use the operator's built-in default. Override per
+  # type to match each workload's profile:
+  #   - policy:    runs tiny Python scripts against JSON; request small
+  #                resources for dense packing.
+  #   - collector: may clone repos and call external APIs; give it headroom.
+  #   - cataloger: similar to collector but typically lighter.
+  #
   # Example:
-  #   snippetContainerSpec:
+  #   snippetContainerSpecPolicy:
   #     resources:
   #       requests:
+  #         cpu: "50m"
+  #         memory: "128Mi"
+  #       limits:
   #         cpu: "500m"
-  #         memory: "1Gi"
-  #     securityContext:
-  #       runAsNonRoot: true
-  snippetContainerSpec: {}
+  #         memory: "256Mi"
+  snippetContainerSpecPolicy: {}
+  snippetContainerSpecCollector: {}
+  snippetContainerSpecCataloger: {}
+
+  # Per-snippet-type batch size: how many jobs the operator groups into a
+  # single pod. Zero = use the operator's built-in default. Policies are cheap
+  # and uniform — pack more per pod to amortize init+sidecar overhead.
+  # Collectors have higher runtime variance, so smaller batches limit blast
+  # radius of slow jobs.
+  # Example:
+  #   batchMaxCountPolicy: 50
+  batchMaxCountPolicy: 0
+  batchMaxCountCollector: 0
+  batchMaxCountCataloger: 0
 
   # Pod-level scheduling for snippet pods. Applied to every pod the operator creates.
   # Example:


### PR DESCRIPTION
## Summary

Complementary chart change for [earthly/lunar#1348](https://github.com/earthly/lunar/pull/1348).

- Removes global `operator.snippetContainerSpec` / `operator.batchMaxCount` (the operator no longer exposes a configurable middle-layer default).
- Adds per-type values: `snippetContainerSpec{Policy,Collector,Cataloger}` and `batchMaxCount{Policy,Collector,Cataloger}`.
- Helm template only emits the corresponding env vars when values are non-empty (specs) or non-zero (counts), so unset values cleanly fall through to the operator's built-in service defaults.

## Test plan

- [ ] `helm lint charts/lunar`
- [ ] `helm template charts/lunar` with all per-type values unset → no `OPERATOR_SNIPPET_CONTAINER_SPEC_*` or `OPERATOR_BATCH_MAX_COUNT_*` env vars emitted
- [ ] `helm template charts/lunar` with `batchMaxCountPolicy: 50` → only the policy env var emitted
- [ ] Cronos deploy picks up new defaults cleanly

Made with [Cursor](https://cursor.com)