### PR TITLE
Release chart 0.5.0: optional PAT, split S3 URL TTLs, README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,439 @@
+# Lunar Helm Charts
+
+Helm charts for deploying [Earthly Lunar](https://earthly.dev/earthly-lunar) on Kubernetes.
+
+## Prerequisites
+
+- Kubernetes 1.29+
+- Helm 3.x
+- PostgreSQL 16+ (external — not included in the chart)
+- S3-compatible object storage (two buckets: logs and resources)
+- A GitHub App installed on your organization — the fastest path to create one is [our manifest script](https://github.com/earthly/lunar/blob/main/scripts/create-github-app.sh) (browser-based flow, prints the credentials you'll need below)
+
+## Installing
+
+```bash
+helm repo add earthly https://earthly.github.io/charts
+helm repo update
+
+helm install lunar earthly/lunar \
+  --namespace lunar --create-namespace \
+  -f values.yaml
+```
+
+Before the command above will succeed, create the [required secrets](#required-secrets) and set the [required values](#required-values).
+
+### Required secrets
+
+The chart references Kubernetes secrets for sensitive values. Create them before installing, or provision them with an external secret manager (External Secrets Operator, Sealed Secrets, Vault, etc.). All secret names and keys are configurable in `values.yaml` — the names below are the defaults.
+
+```bash
+# Database credentials
+kubectl -n lunar create secret generic lunar-db \
+  --from-literal=username='<db-user>' \
+  --from-literal=password='<db-password>'
+
+# Hub auth token (used by CLI and CI agents to authenticate)
+kubectl -n lunar create secret generic lunar-auth-token \
+  --from-literal=token='<generate-a-random-string>'
+
+# GitHub App private key (base64-encoded PEM)
+kubectl -n lunar create secret generic lunar-github-app \
+  --from-file=private-key=path/to/private-key.pem
+
+# GitHub webhook secret
+kubectl -n lunar create secret generic lunar-github-webhook \
+  --from-literal=webhook-secret='<your-webhook-secret>'
+
+# Snippet secrets (can be empty if not needed yet)
+kubectl -n lunar create secret generic lunar-collector-secrets \
+  --from-literal=secrets='{}'
+kubectl -n lunar create secret generic lunar-cataloger-secrets \
+  --from-literal=secrets='{}'
+kubectl -n lunar create secret generic lunar-policy-secrets \
+  --from-literal=secrets='{}'
+```
+
+### Required values
+
+Minimum `values.yaml` that has to be provided — everything else has a sensible default.
+
+```yaml
+hub:
+  publicBaseURL: "https://lunar.example.com"
+
+  db:
+    name: lunar
+    host: your-db-host.example.com
+
+  s3:
+    logsBucket: your-lunar-logs-bucket
+    resourcesBucket: your-lunar-resources-bucket
+
+  github:
+    app:
+      id: 123456
+      installId: 78901234
+```
+
+`hub.publicBaseURL` should resolve to the Hub from the public internet — it's used for automatic GitHub webhook registration (see [Webhooks](#webhooks) below).
+
+## Optional secrets
+
+Only create these if you need the features they enable.
+
+```bash
+# GitHub PAT (legacy; only when hub.github.token.secretName is set.
+# Takes precedence over the GitHub App when present.)
+kubectl -n lunar create secret generic lunar-github-token \
+  --from-literal=token='<your-github-token>'
+
+# Elastic API key (when hub.logging.elastic.url is set)
+kubectl -n lunar create secret generic lunar-elastic-api-key \
+  --from-literal=api-key='<your-elastic-api-key>'
+
+# Grafana admin (when grafana.enabled is true)
+kubectl -n lunar create secret generic lunar-grafana-admin \
+  --from-literal=username='admin' \
+  --from-literal=password='<your-grafana-password>'
+```
+
+## Ingress
+
+```yaml
+hub:
+  ingress:
+    enabled: true
+    className: nginx
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    hosts:
+      - host: lunar.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: lunar-tls
+        hosts:
+          - lunar.example.com
+```
+
+## Post-install
+
+### Load your configuration
+
+Install and configure the [Lunar CLI](https://docs.lunar.build/install/cli) (needs `LUNAR_HUB_HOST` and `LUNAR_HUB_TOKEN` at minimum), then pull your primary configuration into the Hub:
+
+```bash
+lunar hub pull github://your-org/your-config-repo@main
+```
+
+### Webhooks
+
+The Hub automatically registers per-repo GitHub webhooks at `<hub.publicBaseURL>/webhooks/github` when manifests are pulled. No manual webhook configuration is required as long as:
+
+- `hub.publicBaseURL` is set and reachable from GitHub
+- The GitHub App has the `repository_hooks: write` permission (the manifest script grants this by default)
+
+## Upgrading
+
+```bash
+helm repo update
+
+helm upgrade lunar earthly/lunar \
+  --namespace lunar \
+  -f values.yaml
+```
+
+## Uninstalling
+
+```bash
+helm uninstall lunar --namespace lunar
+```
+
+This removes all Kubernetes resources created by the chart. The PVC for hub state is **not** deleted automatically — remove it manually if you want to discard all data.
+
+## Values reference
+
+Run `helm show values earthly/lunar` for the full, authoritative list. Defaults below are grouped by component.
+
+<details>
+<summary><strong>Global</strong></summary>
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `nameOverride` | Override the chart name | `""` |
+| `fullnameOverride` | Override the full release name | `""` |
+| `imagePullSecrets` | Image pull secrets for all pods | `[]` |
+| `serviceAccount.create` | Create a service account | `true` |
+| `serviceAccount.automount` | Automount the service account token | `true` |
+| `serviceAccount.annotations` | Service account annotations (e.g. IAM role ARN) | `{}` |
+| `serviceAccount.name` | Service account name (auto-generated if empty) | `""` |
+
+</details>
+
+<details>
+<summary><strong>Hub</strong></summary>
+
+The central gRPC/HTTP server. Stores metadata, evaluates policies, and serves the API.
+
+**Image**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `hub.image.repository` | Hub container image | `earthly/lunar-hub` |
+| `hub.image.tag` | Image tag | `main` |
+| `hub.image.pullPolicy` | Pull policy | `IfNotPresent` |
+| `hub.extraEnv` | Additional environment variables (`name`/`value` or `valueFrom` pairs) | `[]` |
+
+**Public URL**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `hub.publicBaseURL` | Externally-reachable base URL for the Hub. Required for automatic GitHub webhook registration | `""` |
+
+**Database**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `hub.db.host` | PostgreSQL host | `""` **(required)** |
+| `hub.db.name` | Database name | `""` **(required)** |
+| `hub.db.port` | PostgreSQL port | `5432` |
+| `hub.db.waitSecs` | Seconds to wait for DB readiness on startup | `45` |
+| `hub.db.user.secretName` | Secret containing the DB username | `lunar-db` |
+| `hub.db.user.secretKey` | Key within the secret | `username` |
+| `hub.db.pass.secretName` | Secret containing the DB password | `lunar-db` |
+| `hub.db.pass.secretKey` | Key within the secret | `password` |
+
+**GitHub**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `hub.github.app.id` | GitHub App ID | `0` **(required)** |
+| `hub.github.app.installId` | GitHub App Installation ID | `0` **(required)** |
+| `hub.github.app.privateKey.secretName` | Secret containing the App private key | `lunar-github-app` |
+| `hub.github.app.privateKey.secretKey` | Key within the secret | `private-key` |
+| `hub.github.webhookSecret.secretName` | Secret containing the webhook secret | `lunar-github-webhook` |
+| `hub.github.webhookSecret.secretKey` | Key within the secret | `webhook-secret` |
+| `hub.github.token.secretName` | Legacy PAT secret; empty disables PAT auth (App is used instead) | `""` |
+| `hub.github.token.secretKey` | Key within the secret | `token` |
+| `hub.github.baseUrl` | GitHub API base URL (for GitHub Enterprise Server) | `""` |
+| `hub.github.syncWindow` | How far back to sync GitHub data on first pull | `2160h` (90 days) |
+
+**S3 / Object Storage**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `hub.s3.logsBucket` | S3 bucket for log storage | `""` **(required)** |
+| `hub.s3.resourcesBucket` | S3 bucket for snippet resources | `""` **(required)** |
+| `hub.s3.logsUrlTtl` | Pre-signed URL TTL for snippet log uploads — Go [duration string](https://pkg.go.dev/time#ParseDuration) | `5m` |
+| `hub.s3.resourcesUrlTtl` | Pre-signed URL TTL for snippet resource downloads (init-container fetch) | `1h` |
+
+**Auth**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `hub.auth.secretName` | Secret containing the Hub auth token | `lunar-auth-token` |
+| `hub.auth.secretKey` | Key within the secret | `token` |
+
+**Snippet secrets**
+
+Secrets passed through to collector, cataloger, and policy snippet execution as environment variables. Each references a Kubernetes secret containing a JSON-encoded `map[string]string`.
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `hub.secrets.collector.secretName` | Collector secrets | `lunar-collector-secrets` |
+| `hub.secrets.collector.secretKey` | Key within the secret | `secrets` |
+| `hub.secrets.cataloger.secretName` | Cataloger secrets | `lunar-cataloger-secrets` |
+| `hub.secrets.cataloger.secretKey` | Key within the secret | `secrets` |
+| `hub.secrets.policy.secretName` | Policy secrets | `lunar-policy-secrets` |
+| `hub.secrets.policy.secretKey` | Key within the secret | `secrets` |
+
+**Logging**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `hub.logging.level` | Log level (`debug`, `info`, `warn`, `error`) | `info` |
+| `hub.logging.format` | Log format (`json` or `text`) | `json` |
+| `hub.logging.tenantId` | Tenant identifier for log correlation | `localdev` |
+| `hub.logging.elastic.url` | Elasticsearch URL (enables log shipping when set) | `""` |
+| `hub.logging.elastic.apiKeySecret.secretName` | Elastic API key secret | `lunar-elastic-api-key` |
+| `hub.logging.elastic.apiKeySecret.secretKey` | Key within the secret | `api-key` |
+| `hub.logging.elastic.bufferSize` | Log buffer size before flushing | `100` |
+| `hub.logging.elastic.flushInterval` | How often to flush the log buffer | `5s` |
+
+**Policy queue**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `hub.policyQueue.pollInterval` | How often the queue is polled | `1s` |
+| `hub.policyQueue.numWorkers` | Number of concurrent policy evaluation workers | `5` |
+
+**Persistence**
+
+The Hub uses a PVC for state, cached repos, and snippet code.
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `hub.persistence.enabled` | Create a PVC for hub state | `true` |
+| `hub.persistence.storageClass` | StorageClass (empty = cluster default) | `""` |
+| `hub.persistence.size` | Volume size | `10Gi` |
+| `hub.persistence.accessModes` | PVC access modes | `[ReadWriteOnce]` |
+
+**Networking**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `hub.service.type` | Service type | `ClusterIP` |
+| `hub.service.ports.server` | gRPC port | `8000` |
+| `hub.service.ports.http` | HTTP port | `8001` |
+| `hub.ingress.enabled` | Enable ingress for the Hub | `false` |
+| `hub.ingress.className` | Ingress class | `""` |
+| `hub.ingress.annotations` | Ingress annotations | `{}` |
+| `hub.ingress.hosts` | Ingress host rules | see `values.yaml` |
+| `hub.ingress.tls` | Ingress TLS config | `[]` |
+
+**Probes**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `hub.readinessProbe.enabled` | Enable readiness probe | `true` |
+| `hub.readinessProbe.initialDelaySeconds` | Delay before first check | `0` |
+| `hub.readinessProbe.periodSeconds` | Check interval | `5` |
+| `hub.readinessProbe.failureThreshold` | Failures before unready | `3` |
+| `hub.livenessProbe.enabled` | Enable liveness probe | `true` |
+| `hub.livenessProbe.initialDelaySeconds` | Delay before first check | `0` |
+| `hub.livenessProbe.periodSeconds` | Check interval | `5` |
+| `hub.livenessProbe.failureThreshold` | Failures before restart | `3` |
+
+**Scheduling & pod spec**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `hub.resources` | CPU/memory requests and limits | `{}` |
+| `hub.nodeSelector` | Node selector | `{}` |
+| `hub.tolerations` | Tolerations | `[]` |
+| `hub.affinity` | Affinity rules | `{}` |
+| `hub.labels` | Additional deployment labels | `{}` |
+| `hub.annotations` | Additional deployment annotations | `{}` |
+| `hub.podLabels` | Additional pod labels | `{}` |
+| `hub.podAnnotations` | Additional pod annotations | `{}` |
+| `hub.podSecurityContext` | Pod security context | `{}` |
+| `hub.securityContext` | Container security context | `{}` |
+| `hub.volumeMounts` | Additional volume mounts | `[]` |
+| `hub.volumes` | Additional volumes | `[]` |
+
+</details>
+
+<details>
+<summary><strong>Operator</strong></summary>
+
+Watches for snippet execution jobs and creates Kubernetes pods to run them.
+
+**Images**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `operator.image.repository` | Operator image | `earthly/lunar-snippet-operator` |
+| `operator.image.tag` | Image tag | `main` |
+| `operator.image.pullPolicy` | Pull policy | `IfNotPresent` |
+| `operator.initImage.repository` | Init container image | `earthly/lunar-snippet-init` |
+| `operator.initImage.tag` | Image tag | `main` |
+| `operator.sidecarImage.repository` | Sidecar container image | `earthly/lunar-snippet-sidecar` |
+| `operator.sidecarImage.tag` | Image tag | `main` |
+
+**Behavior**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `operator.snippetNamespace` | Namespace for snippet pods (must exist if set) | `""` (release namespace) |
+| `operator.maxConcurrent` | Max concurrent snippet pods | `10` |
+| `operator.healthPort` | Operator health check port | `8081` |
+| `operator.extraEnv` | Additional environment variables | `[]` |
+
+**Snippet pod configuration**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `operator.snippetContainerSpecPolicy` | Base container spec for policy snippet pods (resources, securityContext, env, etc.) | `{}` |
+| `operator.snippetContainerSpecCollector` | Base container spec for collector snippet pods | `{}` |
+| `operator.snippetContainerSpecCataloger` | Base container spec for cataloger snippet pods | `{}` |
+| `operator.batchMaxCountPolicy` | Max jobs per policy pod; `0` uses the operator default | `0` |
+| `operator.batchMaxCountCollector` | Max jobs per collector pod; `0` uses the operator default | `0` |
+| `operator.batchMaxCountCataloger` | Max jobs per cataloger pod; `0` uses the operator default | `0` |
+| `operator.snippetPodNodeSelector` | Node selector for snippet pods | `{}` |
+| `operator.snippetPodTolerations` | Tolerations for snippet pods | `[]` |
+
+**Logging**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `operator.logging.level` | Log level | `info` |
+| `operator.logging.format` | Log format | `json` |
+| `operator.logging.tenantId` | Tenant identifier | `localdev` |
+| `operator.logging.elastic.*` | Same structure as `hub.logging.elastic.*` | — |
+
+**Scheduling & pod spec**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `operator.resources` | CPU/memory requests and limits | `{}` |
+| `operator.nodeSelector` | Node selector | `{}` |
+| `operator.tolerations` | Tolerations | `[]` |
+| `operator.affinity` | Affinity rules | `{}` |
+| `operator.podLabels` | Additional pod labels | `{}` |
+| `operator.podAnnotations` | Additional pod annotations | `{}` |
+| `operator.podSecurityContext` | Pod security context | `{}` |
+| `operator.securityContext` | Container security context | `{}` |
+
+</details>
+
+<details>
+<summary><strong>Badges</strong></summary>
+
+Optional service that generates embeddable SVG status badges for components.
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `badges.enabled` | Deploy the badge service | `false` |
+| `badges.secure` | Hub connects to badges over HTTPS | `false` |
+| `badges.image.repository` | Badges image | `earthly/badges` |
+| `badges.image.tag` | Image tag | `main` |
+| `badges.secret.name` | Secret containing the badges auth token | `""` |
+| `badges.secret.key` | Key within the secret | `""` |
+| `badges.service.type` | Service type | `ClusterIP` |
+| `badges.service.port` | Service port | `80` |
+| `badges.ingress.*` | Same structure as `hub.ingress.*` | disabled |
+| `badges.extraEnv` | Additional environment variables | `[]` |
+| `badges.resources` | CPU/memory requests and limits | `{}` |
+| `badges.nodeSelector` | Node selector | `{}` |
+| `badges.tolerations` | Tolerations | `[]` |
+| `badges.affinity` | Affinity rules | `{}` |
+
+</details>
+
+<details>
+<summary><strong>Grafana</strong></summary>
+
+Optional pre-built Grafana instance with dashboards for policy results, component health, and collection activity.
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `grafana.enabled` | Deploy the pre-built Grafana instance | `false` |
+| `grafana.image.repository` | Grafana image | `earthly/lunar-grafana` |
+| `grafana.image.tag` | Image tag | `main` |
+| `grafana.admin.user.secretName` | Secret containing the admin username | `lunar-grafana-admin` |
+| `grafana.admin.user.secretKey` | Key within the secret | `username` |
+| `grafana.admin.password.secretName` | Secret containing the admin password | `lunar-grafana-admin` |
+| `grafana.admin.password.secretKey` | Key within the secret | `password` |
+| `grafana.service.type` | Service type | `ClusterIP` |
+| `grafana.service.port` | Service port | `80` |
+| `grafana.ingress.*` | Same structure as `hub.ingress.*` | disabled |
+| `grafana.extraEnv` | Additional environment variables | `[]` |
+| `grafana.resources` | CPU/memory requests and limits | `{}` |
+| `grafana.nodeSelector` | Node selector | `{}` |
+| `grafana.tolerations` | Tolerations | `[]` |
+| `grafana.affinity` | Affinity rules | `{}` |
+
+</details>

--- a/README.md
+++ b/README.md
@@ -37,21 +37,13 @@ kubectl -n lunar create secret generic lunar-db \
 kubectl -n lunar create secret generic lunar-auth-token \
   --from-literal=token='<generate-a-random-string>'
 
-# GitHub App private key (base64-encoded PEM)
+# GitHub App private key (PEM) — required when using App auth
 kubectl -n lunar create secret generic lunar-github-app \
   --from-file=private-key=path/to/private-key.pem
 
 # GitHub webhook secret
 kubectl -n lunar create secret generic lunar-github-webhook \
   --from-literal=webhook-secret='<your-webhook-secret>'
-
-# Snippet secrets (can be empty if not needed yet)
-kubectl -n lunar create secret generic lunar-collector-secrets \
-  --from-literal=secrets='{}'
-kubectl -n lunar create secret generic lunar-cataloger-secrets \
-  --from-literal=secrets='{}'
-kubectl -n lunar create secret generic lunar-policy-secrets \
-  --from-literal=secrets='{}'
 ```
 
 ### Required values
@@ -78,15 +70,66 @@ hub:
 
 `hub.publicBaseURL` should resolve to the Hub from the public internet — it's used for automatic GitHub webhook registration (see [Webhooks](#webhooks) below).
 
+### GitHub authentication
+
+Configure **exactly one** of GitHub App or Personal Access Token. The chart validates this at install time with `helm.sh/fail`:
+
+- **App (recommended):** set `hub.github.app.id` + `hub.github.app.installId` + create the `lunar-github-app` secret.
+- **PAT (legacy):** set `hub.github.token.secretName` and leave `hub.github.app.id` / `installId` at `0`. The App private-key secret is not needed.
+
+Both configured = install fails. Neither configured = install fails.
+
+### Object storage & AWS credentials
+
+Lunar uses two S3-compatible buckets — one for streaming snippet logs, one for snippet resource archives fetched by init containers. Both must exist and be writable before pods start doing real work.
+
+**AWS credentials are intentionally out of scope for this chart.** The hub uses the standard AWS SDK credential chain, so you can use whichever mechanism fits your cluster:
+
+- **IRSA (recommended on EKS)** — annotate the chart's service account with the role ARN. The role needs `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject` on both buckets.
+
+  ```yaml
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/lunar-hub-s3
+  hub:
+    extraEnv:
+      - name: AWS_REGION
+        value: us-east-1
+  ```
+
+- **Explicit env vars** — inject credentials via `hub.extraEnv`, sourced from an existing secret:
+
+  ```yaml
+  hub:
+    extraEnv:
+      - name: AWS_REGION
+        value: us-east-1
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef: { name: lunar-aws, key: access-key-id }
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef: { name: lunar-aws, key: secret-access-key }
+  ```
+
+Other providers (GKE Workload Identity, pod identity, IMDS, etc.) all work the same way — set whatever `AWS_*` or service-account plumbing you'd normally use for any AWS-SDK workload. The chart does not create the buckets for you.
+
 ## Optional secrets
 
 Only create these if you need the features they enable.
 
 ```bash
-# GitHub PAT (legacy; only when hub.github.token.secretName is set.
-# Takes precedence over the GitHub App when present.)
+# GitHub PAT (legacy; only when hub.github.token.secretName is set)
 kubectl -n lunar create secret generic lunar-github-token \
   --from-literal=token='<your-github-token>'
+
+# Per-scope runtime secrets (only when the matching hub.secrets.*.secretName is set).
+# Values are JSON-encoded map[string]string, made available to snippets by the hub.
+# Most installs don't need these — prefer per-type snippet container spec envFrom /
+# volumes (see operator.snippetContainerSpec*) for fine-grained control.
+kubectl -n lunar create secret generic lunar-collector-secrets --from-literal=secrets='{}'
+kubectl -n lunar create secret generic lunar-cataloger-secrets --from-literal=secrets='{}'
+kubectl -n lunar create secret generic lunar-policy-secrets    --from-literal=secrets='{}'
 
 # Elastic API key (when hub.logging.elastic.url is set)
 kubectl -n lunar create secret generic lunar-elastic-api-key \
@@ -145,6 +188,15 @@ helm upgrade lunar earthly/lunar \
   --namespace lunar \
   -f values.yaml
 ```
+
+### Upgrading from 0.4.x to 0.5.x
+
+0.5.0 tightens defaults to match what the hub actually requires. Review these before bumping:
+
+- **`hub.s3.urlExpirationMinutes` is removed.** Set `hub.s3.logsUrlTtl` (default `5m`) and `hub.s3.resourcesUrlTtl` (default `1h`) instead.
+- **GitHub PAT is now optional.** If you've been using the GitHub App, you can delete the `lunar-github-token` placeholder secret — the chart no longer injects `HUB_GITHUB_TOKEN` unless `hub.github.token.secretName` is set. The chart also now fails at install if both App and PAT are configured, or if neither is.
+- **Runtime snippet secrets are now optional.** `hub.secrets.{collector,cataloger,policy}.secretName` default to `""` (previously `lunar-collector-secrets` etc.). If you actually use runtime secrets, set each `secretName` explicitly in your values — otherwise delete the three placeholder secrets.
+- **`hub.publicBaseURL` is now documented as required** for automatic GitHub webhook registration. Nothing changed in the template, but if you never set it, webhooks were silently failing. Set it.
 
 ## Uninstalling
 
@@ -208,15 +260,17 @@ The central gRPC/HTTP server. Stores metadata, evaluates policies, and serves th
 
 **GitHub**
 
+Configure **exactly one** of App auth or PAT auth — the chart fails at install time otherwise. See [GitHub authentication](#github-authentication).
+
 | Key | Description | Default |
 |-----|-------------|---------|
-| `hub.github.app.id` | GitHub App ID | `0` **(required)** |
-| `hub.github.app.installId` | GitHub App Installation ID | `0` **(required)** |
-| `hub.github.app.privateKey.secretName` | Secret containing the App private key | `lunar-github-app` |
+| `hub.github.app.id` | GitHub App ID (required for App auth) | `0` |
+| `hub.github.app.installId` | GitHub App Installation ID (required for App auth) | `0` |
+| `hub.github.app.privateKey.secretName` | Secret containing the App private key (required for App auth) | `lunar-github-app` |
 | `hub.github.app.privateKey.secretKey` | Key within the secret | `private-key` |
 | `hub.github.webhookSecret.secretName` | Secret containing the webhook secret | `lunar-github-webhook` |
 | `hub.github.webhookSecret.secretKey` | Key within the secret | `webhook-secret` |
-| `hub.github.token.secretName` | Legacy PAT secret; empty disables PAT auth (App is used instead) | `""` |
+| `hub.github.token.secretName` | Legacy PAT secret; set this (and leave `app.id` / `installId` at `0`) to use PAT auth | `""` |
 | `hub.github.token.secretKey` | Key within the secret | `token` |
 | `hub.github.baseUrl` | GitHub API base URL (for GitHub Enterprise Server) | `""` |
 | `hub.github.syncWindow` | How far back to sync GitHub data on first pull | `2160h` (90 days) |
@@ -237,17 +291,17 @@ The central gRPC/HTTP server. Stores metadata, evaluates policies, and serves th
 | `hub.auth.secretName` | Secret containing the Hub auth token | `lunar-auth-token` |
 | `hub.auth.secretKey` | Key within the secret | `token` |
 
-**Snippet secrets**
+**Snippet secrets (optional)**
 
-Secrets passed through to collector, cataloger, and policy snippet execution as environment variables. Each references a Kubernetes secret containing a JSON-encoded `map[string]string`.
+Per-scope secrets the hub forwards to snippet execution as JSON-encoded `map[string]string` env vars. Most installs don't need these — per-type container spec `envFrom` / `volumes` on `operator.snippetContainerSpec*` is usually a cleaner path. Leave `secretName` empty to skip injection entirely.
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `hub.secrets.collector.secretName` | Collector secrets | `lunar-collector-secrets` |
+| `hub.secrets.collector.secretName` | Collector secrets; empty disables | `""` |
 | `hub.secrets.collector.secretKey` | Key within the secret | `secrets` |
-| `hub.secrets.cataloger.secretName` | Cataloger secrets | `lunar-cataloger-secrets` |
+| `hub.secrets.cataloger.secretName` | Cataloger secrets; empty disables | `""` |
 | `hub.secrets.cataloger.secretKey` | Key within the secret | `secrets` |
-| `hub.secrets.policy.secretName` | Policy secrets | `lunar-policy-secrets` |
+| `hub.secrets.policy.secretName` | Policy secrets; empty disables | `""` |
 | `hub.secrets.policy.secretKey` | Key within the secret | `secrets` |
 
 **Logging**

--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ kubectl -n lunar create secret generic lunar-db \
 kubectl -n lunar create secret generic lunar-auth-token \
   --from-literal=token='<generate-a-random-string>'
 
-# GitHub App private key (PEM) — required when using App auth
+# GitHub App private key — required when using App auth.
+# The hub base64-decodes this value internally, so the secret must contain the
+# base64-encoded PEM (not the raw PEM). The one-liner below works on both
+# GNU and BSD/macOS base64.
 kubectl -n lunar create secret generic lunar-github-app \
-  --from-file=private-key=path/to/private-key.pem
+  --from-literal=private-key="$(base64 < path/to/private-key.pem | tr -d '\n')"
 
 # GitHub webhook secret
 kubectl -n lunar create secret generic lunar-github-webhook \

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 0.4.12
+version: 0.5.0
+kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/NOTES.txt
+++ b/charts/lunar/templates/NOTES.txt
@@ -12,15 +12,29 @@ Hub (required):
   {{ printf "%-30s" .Values.hub.db.user.secretName }}  key: {{ .Values.hub.db.user.secretKey }}
   {{ printf "%-30s" .Values.hub.db.pass.secretName }}  key: {{ .Values.hub.db.pass.secretKey }}
   {{ printf "%-30s" .Values.hub.auth.secretName }}  key: {{ .Values.hub.auth.secretKey }}
-  {{ printf "%-30s" .Values.hub.github.app.privateKey.secretName }}  key: {{ .Values.hub.github.app.privateKey.secretKey }}
   {{ printf "%-30s" .Values.hub.github.webhookSecret.secretName }}  key: {{ .Values.hub.github.webhookSecret.secretKey }}
-  {{ printf "%-30s" .Values.hub.secrets.collector.secretName }}  key: {{ .Values.hub.secrets.collector.secretKey }}
-  {{ printf "%-30s" .Values.hub.secrets.cataloger.secretName }}  key: {{ .Values.hub.secrets.cataloger.secretKey }}
-  {{ printf "%-30s" .Values.hub.secrets.policy.secretName }}  key: {{ .Values.hub.secrets.policy.secretKey }}
+{{- if include "lunar.hasGitHubApp" . }}
+
+GitHub App (required when app.id and app.installId are set):
+  {{ printf "%-30s" .Values.hub.github.app.privateKey.secretName }}  key: {{ .Values.hub.github.app.privateKey.secretKey }}
+{{- end }}
 {{- if .Values.hub.github.token.secretName }}
 
 GitHub PAT (legacy; when hub.github.token.secretName is set):
   {{ printf "%-30s" .Values.hub.github.token.secretName }}  key: {{ .Values.hub.github.token.secretKey }}
+{{- end }}
+{{- if or .Values.hub.secrets.collector.secretName .Values.hub.secrets.cataloger.secretName .Values.hub.secrets.policy.secretName }}
+
+Runtime secrets (optional; only when the corresponding secretName is set):
+{{- if .Values.hub.secrets.collector.secretName }}
+  {{ printf "%-30s" .Values.hub.secrets.collector.secretName }}  key: {{ .Values.hub.secrets.collector.secretKey }}
+{{- end }}
+{{- if .Values.hub.secrets.cataloger.secretName }}
+  {{ printf "%-30s" .Values.hub.secrets.cataloger.secretName }}  key: {{ .Values.hub.secrets.cataloger.secretKey }}
+{{- end }}
+{{- if .Values.hub.secrets.policy.secretName }}
+  {{ printf "%-30s" .Values.hub.secrets.policy.secretName }}  key: {{ .Values.hub.secrets.policy.secretKey }}
+{{- end }}
 {{- end }}
 {{- if .Values.hub.logging.elastic.url }}
 

--- a/charts/lunar/templates/NOTES.txt
+++ b/charts/lunar/templates/NOTES.txt
@@ -13,11 +13,15 @@ Hub (required):
   {{ printf "%-30s" .Values.hub.db.pass.secretName }}  key: {{ .Values.hub.db.pass.secretKey }}
   {{ printf "%-30s" .Values.hub.auth.secretName }}  key: {{ .Values.hub.auth.secretKey }}
   {{ printf "%-30s" .Values.hub.github.app.privateKey.secretName }}  key: {{ .Values.hub.github.app.privateKey.secretKey }}
-  {{ printf "%-30s" .Values.hub.github.token.secretName }}  key: {{ .Values.hub.github.token.secretKey }}
   {{ printf "%-30s" .Values.hub.github.webhookSecret.secretName }}  key: {{ .Values.hub.github.webhookSecret.secretKey }}
   {{ printf "%-30s" .Values.hub.secrets.collector.secretName }}  key: {{ .Values.hub.secrets.collector.secretKey }}
   {{ printf "%-30s" .Values.hub.secrets.cataloger.secretName }}  key: {{ .Values.hub.secrets.cataloger.secretKey }}
   {{ printf "%-30s" .Values.hub.secrets.policy.secretName }}  key: {{ .Values.hub.secrets.policy.secretKey }}
+{{- if .Values.hub.github.token.secretName }}
+
+GitHub PAT (legacy; when hub.github.token.secretName is set):
+  {{ printf "%-30s" .Values.hub.github.token.secretName }}  key: {{ .Values.hub.github.token.secretKey }}
+{{- end }}
 {{- if .Values.hub.logging.elastic.url }}
 
 Elastic (when hub.logging.elastic.url is set):

--- a/charts/lunar/templates/_helpers.tpl
+++ b/charts/lunar/templates/_helpers.tpl
@@ -67,3 +67,42 @@ Namespace where snippet pods run. Defaults to the release namespace.
 {{- define "lunar.snippetNamespace" -}}
 {{- .Values.operator.snippetNamespace | default .Release.Namespace }}
 {{- end }}
+
+{{/*
+Does the install look like it's configured for GitHub App auth?
+True when both the numeric app.id and app.installId are non-zero.
+*/}}
+{{- define "lunar.hasGitHubApp" -}}
+{{- if and (gt (int .Values.hub.github.app.id) 0) (gt (int .Values.hub.github.app.installId) 0) -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Does the install look like it's configured for GitHub PAT auth?
+True when hub.github.token.secretName is set.
+*/}}
+{{- define "lunar.hasGitHubPAT" -}}
+{{- if .Values.hub.github.token.secretName -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Fail fast when GitHub auth is misconfigured. Exactly one of App or PAT
+must be configured — both is almost always a mistake, neither leaves
+the hub unable to talk to GitHub.
+*/}}
+{{- define "lunar.githubAuthCheck" -}}
+{{- $hasApp := include "lunar.hasGitHubApp" . -}}
+{{- $hasPAT := include "lunar.hasGitHubPAT" . -}}
+{{- if and $hasApp $hasPAT -}}
+{{- fail "hub.github: configure either GitHub App auth (app.id + app.installId + app.privateKey) OR a PAT (token.secretName), not both." -}}
+{{- end -}}
+{{- if and (not $hasApp) (not $hasPAT) -}}
+{{- fail "hub.github: no auth configured. Set GitHub App values (app.id + app.installId + app.privateKey.secretName) or a PAT (token.secretName)." -}}
+{{- end -}}
+{{- if and $hasApp (not .Values.hub.github.app.privateKey.secretName) -}}
+{{- fail "hub.github.app: privateKey.secretName is required when app.id and app.installId are set." -}}
+{{- end -}}
+{{- end }}

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -74,11 +74,13 @@ spec:
                 secretKeyRef:
                   name: {{ .github.webhookSecret.secretName }}
                   key: {{ .github.webhookSecret.secretKey }}
+            {{- if .github.token.secretName }}
             - name: HUB_GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .github.token.secretName }}
                   key: {{ .github.token.secretKey }}
+            {{- end }}
             - name: HUB_GITHUB_SYNC_WINDOW
               value: {{ .github.syncWindow | quote }}
             - name: HUB_GITHUB_BASE_URL
@@ -140,7 +142,9 @@ spec:
             - name: HUB_RESOURCES_AWS_BUCKET
               value: {{ .s3.resourcesBucket | quote }}
             - name: HUB_LOGS_AWS_URL_TTL
-              value: {{ .s3.urlExpirationMinutes | quote }}
+              value: {{ .s3.logsUrlTtl | quote }}
+            - name: HUB_RESOURCES_AWS_URL_TTL
+              value: {{ .s3.resourcesUrlTtl | quote }}
             {{- if .publicBaseURL }}
             - name: HUB_PUBLIC_BASE_URL
               value: {{ .publicBaseURL | quote }}

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "lunar.githubAuthCheck" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -85,6 +86,7 @@ spec:
               value: {{ .github.syncWindow | quote }}
             - name: HUB_GITHUB_BASE_URL
               value: {{ .github.baseUrl | quote }}
+            {{- if include "lunar.hasGitHubApp" $ }}
             - name: HUB_GITHUB_APP_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:
@@ -94,6 +96,7 @@ spec:
               value: {{ .github.app.id | quote }}
             - name: HUB_GITHUB_APP_INSTALL_ID
               value: {{ .github.app.installId | quote }}
+            {{- end }}
             - name: HUB_POLICY_QUEUE_POLL_INTERVAL
               value: {{ .policyQueue.pollInterval | quote }}
             - name: HUB_POLICY_QUEUE_NUM_WORKERS
@@ -103,21 +106,27 @@ spec:
                 secretKeyRef:
                   name: {{ .auth.secretName }}
                   key: {{ .auth.secretKey }}
+            {{- if .secrets.collector.secretName }}
             - name: HUB_COLLECTOR_SECRETS
               valueFrom:
                 secretKeyRef:
                   name: {{ .secrets.collector.secretName }}
                   key: {{ .secrets.collector.secretKey }}
+            {{- end }}
+            {{- if .secrets.cataloger.secretName }}
             - name: HUB_CATALOGER_SECRETS
               valueFrom:
                 secretKeyRef:
                   name: {{ .secrets.cataloger.secretName }}
                   key: {{ .secrets.cataloger.secretKey }}
+            {{- end }}
+            {{- if .secrets.policy.secretName }}
             - name: HUB_POLICY_SECRETS
               valueFrom:
                 secretKeyRef:
                   name: {{ .secrets.policy.secretName }}
                   key: {{ .secrets.policy.secretKey }}
+            {{- end }}
             - name: HUB_TENANT_ID
               value: {{ .logging.tenantId | quote }}
             - name: HUB_LOG_LEVEL

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -50,7 +50,14 @@ hub:
   policyQueue:
     pollInterval: 1s
     numWorkers: 5
+  # S3-compatible object storage for snippet logs and resource archives.
+  # The buckets must exist and be writable by the hub's AWS credentials.
+  # AWS credentials themselves are intentionally out of scope for this
+  # chart — see README "Object storage & AWS credentials" for options
+  # (IRSA on EKS, explicit AWS_* via hub.extraEnv, etc.).
   s3:
+    # Bucket names are effectively required — empty values make every log
+    # upload and every snippet resource fetch fail at runtime.
     logsBucket: ""
     resourcesBucket: ""
     # TTL for pre-signed URLs, as Go duration strings
@@ -64,15 +71,19 @@ hub:
   auth:
     secretName: "lunar-auth-token"
     secretKey: "token"
+  # Optional per-scope runtime secrets, exposed to snippets via the hub's
+  # "lunar secret set" workflow. Leave secretName empty to skip injection —
+  # snippets can alternatively read secrets from envFrom / volumes declared
+  # on the per-type operator.snippetContainerSpec* you control.
   secrets:
     collector:
-      secretName: "lunar-collector-secrets"
+      secretName: ""
       secretKey: "secrets"
     cataloger:
-      secretName: "lunar-cataloger-secrets"
+      secretName: ""
       secretKey: "secrets"
     policy:
-      secretName: "lunar-policy-secrets"
+      secretName: ""
       secretKey: "secrets"
   logging:
     tenantId: "localdev"

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -41,8 +41,10 @@ hub:
     webhookSecret:
       secretName: "lunar-github-webhook"
       secretKey: "webhook-secret"
+    # Optional legacy PAT auth. Leave secretName empty when using the GitHub App —
+    # the env var will not be injected. If set, the PAT takes precedence over the App.
     token:
-      secretName: "lunar-github-token"
+      secretName: ""
       secretKey: "token"
     syncWindow: 2160h
   policyQueue:
@@ -51,7 +53,14 @@ hub:
   s3:
     logsBucket: ""
     resourcesBucket: ""
-    urlExpirationMinutes: 5m
+    # TTL for pre-signed URLs, as Go duration strings
+    # (see https://pkg.go.dev/time#ParseDuration), e.g. "5m", "1h".
+    # - logsUrlTtl: PUT URLs for snippet log uploads during execution.
+    # - resourcesUrlTtl: GET URLs for snippet resource archives fetched
+    #   by init containers before execution; leave generous to absorb
+    #   pod scheduling / image pull / cluster backpressure.
+    logsUrlTtl: 5m
+    resourcesUrlTtl: 1h
   auth:
     secretName: "lunar-auth-token"
     secretKey: "token"


### PR DESCRIPTION
## Summary

Ships `lunar` chart **0.5.0**. Makes the chart match what the hub actually requires at runtime — no more placeholder secrets for code paths you're not using — and documents what was previously unwritten tribal knowledge.

### Breaking changes

1. **`hub.s3.urlExpirationMinutes` removed.** Set `hub.s3.logsUrlTtl` (default `5m`, for log PUT URLs) and `hub.s3.resourcesUrlTtl` (default `1h`, for snippet resource GET URLs) — the two have different operational concerns and different Go backend defaults.
2. **Runtime snippet secrets are opt-in.** `hub.secrets.{collector,cataloger,policy}.secretName` default to `""`. Existing installs that actually populated `lunar-{collector,cataloger,policy}-secrets` need to set each `secretName` explicitly in their values. Most installs should delete the now-unused placeholder secrets. The backend always tolerated empty maps; the modern path is per-type container-spec `envFrom` / volumes on `operator.snippetContainerSpec*`.

### Functional changes

1. **GitHub PAT is optional and XOR with App.** `hub.github.token.secretName` defaults to `""`; `HUB_GITHUB_TOKEN` is injected only when set. GitHub App env vars (`HUB_GITHUB_APP_PRIVATE_KEY` / `_APP_ID` / `_APP_INSTALL_ID`) are injected only when `app.id` and `app.installId` are both `> 0`. The chart now fails at install time (`{{ fail }}` via a helper) if both are configured or neither is — no more silently-broken GitHub integration.
2. **Runtime-secret `secretKeyRef`s are conditional** — pods no longer fail to start because of placeholder secrets you never populate.
3. **Declares `kubeVersion: ">=1.29.0-0"`** (validated via `kubeconform` sweep).
4. **`hub.publicBaseURL` (added upstream in #14) is now documented as effectively-required** for automatic GitHub webhook registration.

### Docs / DX

- README rewritten in Helm-idiomatic shape: Prerequisites, Installing (with Required secrets / Required values), GitHub authentication, **Object storage & AWS credentials** (new — explains why AWS auth is out of scope and documents the IRSA + explicit-env-var recipes), Optional secrets, Ingress, Post-install, Upgrading (including **Upgrading from 0.4.x** breakdown), Uninstalling, and a collapsible per-component Values reference.
- Links to the GitHub App manifest script (`lunar/scripts/create-github-app.sh`) and the Lunar CLI env-var docs.
- `NOTES.txt` moves optional secrets (runtime trio, App private key, PAT) into conditional blocks — the "required" list now reflects reality.

## Deferred to followups (out of scope here)

- `helm-docs` adoption — generate the values-reference section from `values.yaml` comments.
- `util/github/webhooks.go` swallows `422 Unprocessable Entity` silently on webhook registration — worth reclassifying as warn+.
- `POV-SETUP-GUIDE.md` — drop the manual `enable-webhook.sh` step once tenants land on 0.5.0.
- Parallel conditionalization for `hub.github.webhookSecret` (same shape as runtime trio; not obviously a cleanup win, kept unchanged here).

## Test plan

- [x] `helm lint charts/lunar` — clean
- [x] `helm template` + `kubeconform -strict` — 13/13 valid (App path), 11/11 valid (PAT path)
- [x] Default render emits `HUB_LOGS_AWS_URL_TTL=5m` and `HUB_RESOURCES_AWS_URL_TTL=1h`; override render honors custom values
- [x] App path renders `HUB_GITHUB_APP_*`, no PAT
- [x] PAT path renders `HUB_GITHUB_TOKEN`, no App env vars
- [x] Both App and PAT configured → `helm template` fails with clear message
- [x] Neither configured → `helm template` fails with clear message
- [x] App configured without private-key secret → `helm template` fails with clear message
- [x] Runtime secrets injected only when `secretName` is set; `NOTES.txt` reflects which ones are active
- [x] `HUB_PUBLIC_BASE_URL` rendered only when `hub.publicBaseURL` is set
- [ ] Roll out via demo-eks GHA workflow post-merge (owner will handle)