### PR TITLE
chart: remove Hub PAT auth path (0.5.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,7 @@ hub:
 
 ### GitHub authentication
 
-Configure **exactly one** of GitHub App or Personal Access Token. The chart validates this at install time with `helm.sh/fail`:
-
-- **App (recommended):** set `hub.github.app.id` + `hub.github.app.installId` + create the `lunar-github-app` secret.
-- **PAT (legacy):** set `hub.github.token.secretName` and leave `hub.github.app.id` / `installId` at `0`. The App private-key secret is not needed.
-
-Both configured = install fails. Neither configured = install fails.
+Hub authenticates to GitHub as a GitHub App. Set `hub.github.app.id` + `hub.github.app.installId` and create the `lunar-github-app` secret holding the App's private-key PEM. The chart validates these at install time with `helm.sh/fail`.
 
 ### Object storage & AWS credentials
 
@@ -122,10 +117,6 @@ Other providers (GKE Workload Identity, pod identity, IMDS, etc.) all work the s
 Only create these if you need the features they enable.
 
 ```bash
-# GitHub PAT (legacy; only when hub.github.token.secretName is set)
-kubectl -n lunar create secret generic lunar-github-token \
-  --from-literal=token='<your-github-token>'
-
 # Per-scope runtime secrets (only when the matching hub.secrets.*.secretName is set).
 # Values are JSON-encoded map[string]string, made available to snippets by the hub.
 # Most installs don't need these — prefer per-type snippet container spec envFrom /
@@ -197,7 +188,7 @@ helm upgrade lunar earthly/lunar \
 0.5.0 tightens defaults to match what the hub actually requires. Review these before bumping:
 
 - **`hub.s3.urlExpirationMinutes` is removed.** Set `hub.s3.logsUrlTtl` (default `5m`) and `hub.s3.resourcesUrlTtl` (default `1h`) instead.
-- **GitHub PAT is now optional.** If you've been using the GitHub App, you can delete the `lunar-github-token` placeholder secret — the chart no longer injects `HUB_GITHUB_TOKEN` unless `hub.github.token.secretName` is set. The chart also now fails at install if both App and PAT are configured, or if neither is.
+- **GitHub PAT auth is removed.** Hub now authenticates as a GitHub App only. Set `hub.github.app.id` + `hub.github.app.installId` and create the App private-key secret. The `hub.github.token.*` values are gone; the `lunar-github-token` placeholder secret can be deleted.
 - **Runtime snippet secrets are now optional.** `hub.secrets.{collector,cataloger,policy}.secretName` default to `""` (previously `lunar-collector-secrets` etc.). If you actually use runtime secrets, set each `secretName` explicitly in your values — otherwise delete the three placeholder secrets.
 - **`hub.publicBaseURL` is now documented as required** for automatic GitHub webhook registration. Nothing changed in the template, but if you never set it, webhooks were silently failing. Set it.
 
@@ -263,18 +254,16 @@ The central gRPC/HTTP server. Stores metadata, evaluates policies, and serves th
 
 **GitHub**
 
-Configure **exactly one** of App auth or PAT auth — the chart fails at install time otherwise. See [GitHub authentication](#github-authentication).
+Hub authenticates as a GitHub App. App ID, install ID, and the App's private-key secret are all required — the chart fails at install time otherwise. See [GitHub authentication](#github-authentication).
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `hub.github.app.id` | GitHub App ID (required for App auth) | `0` |
-| `hub.github.app.installId` | GitHub App Installation ID (required for App auth) | `0` |
-| `hub.github.app.privateKey.secretName` | Secret containing the App private key (required for App auth) | `lunar-github-app` |
+| `hub.github.app.id` | GitHub App ID | `0` **(required)** |
+| `hub.github.app.installId` | GitHub App Installation ID | `0` **(required)** |
+| `hub.github.app.privateKey.secretName` | Secret containing the App private-key PEM | `lunar-github-app` |
 | `hub.github.app.privateKey.secretKey` | Key within the secret | `private-key` |
 | `hub.github.webhookSecret.secretName` | Secret containing the webhook secret | `lunar-github-webhook` |
 | `hub.github.webhookSecret.secretKey` | Key within the secret | `webhook-secret` |
-| `hub.github.token.secretName` | Legacy PAT secret; set this (and leave `app.id` / `installId` at `0`) to use PAT auth | `""` |
-| `hub.github.token.secretKey` | Key within the secret | `token` |
 | `hub.github.baseUrl` | GitHub API base URL (for GitHub Enterprise Server) | `""` |
 | `hub.github.syncWindow` | How far back to sync GitHub data on first pull | `2160h` (90 days) |
 

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 0.5.2
+version: 0.5.3
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/NOTES.txt
+++ b/charts/lunar/templates/NOTES.txt
@@ -13,16 +13,9 @@ Hub (required):
   {{ printf "%-30s" .Values.hub.db.pass.secretName }}  key: {{ .Values.hub.db.pass.secretKey }}
   {{ printf "%-30s" .Values.hub.auth.secretName }}  key: {{ .Values.hub.auth.secretKey }}
   {{ printf "%-30s" .Values.hub.github.webhookSecret.secretName }}  key: {{ .Values.hub.github.webhookSecret.secretKey }}
-{{- if include "lunar.hasGitHubApp" . }}
 
-GitHub App (required when app.id and app.installId are set):
+GitHub App (required):
   {{ printf "%-30s" .Values.hub.github.app.privateKey.secretName }}  key: {{ .Values.hub.github.app.privateKey.secretKey }}
-{{- end }}
-{{- if .Values.hub.github.token.secretName }}
-
-GitHub PAT (legacy; when hub.github.token.secretName is set):
-  {{ printf "%-30s" .Values.hub.github.token.secretName }}  key: {{ .Values.hub.github.token.secretKey }}
-{{- end }}
 {{- if or .Values.hub.secrets.collector.secretName .Values.hub.secrets.cataloger.secretName .Values.hub.secrets.policy.secretName }}
 
 Runtime secrets (optional; only when the corresponding secretName is set):

--- a/charts/lunar/templates/_helpers.tpl
+++ b/charts/lunar/templates/_helpers.tpl
@@ -69,40 +69,16 @@ Namespace where snippet pods run. Defaults to the release namespace.
 {{- end }}
 
 {{/*
-Does the install look like it's configured for GitHub App auth?
-True when both the numeric app.id and app.installId are non-zero.
-*/}}
-{{- define "lunar.hasGitHubApp" -}}
-{{- if and (gt (int .Values.hub.github.app.id) 0) (gt (int .Values.hub.github.app.installId) 0) -}}
-true
-{{- end -}}
-{{- end }}
-
-{{/*
-Does the install look like it's configured for GitHub PAT auth?
-True when hub.github.token.secretName is set.
-*/}}
-{{- define "lunar.hasGitHubPAT" -}}
-{{- if .Values.hub.github.token.secretName -}}
-true
-{{- end -}}
-{{- end }}
-
-{{/*
-Fail fast when GitHub auth is misconfigured. Exactly one of App or PAT
-must be configured — both is almost always a mistake, neither leaves
-the hub unable to talk to GitHub.
+Fail fast when GitHub App auth is misconfigured.
 */}}
 {{- define "lunar.githubAuthCheck" -}}
-{{- $hasApp := include "lunar.hasGitHubApp" . -}}
-{{- $hasPAT := include "lunar.hasGitHubPAT" . -}}
-{{- if and $hasApp $hasPAT -}}
-{{- fail "hub.github: configure either GitHub App auth (app.id + app.installId + app.privateKey) OR a PAT (token.secretName), not both." -}}
+{{- if not (gt (int .Values.hub.github.app.id) 0) -}}
+{{- fail "hub.github.app.id is required (numeric, non-zero). Run scripts/create-github-app.sh in the lunar repo to create one if you don't have it yet." -}}
 {{- end -}}
-{{- if and (not $hasApp) (not $hasPAT) -}}
-{{- fail "hub.github: no auth configured. Set GitHub App values (app.id + app.installId + app.privateKey.secretName) or a PAT (token.secretName)." -}}
+{{- if not (gt (int .Values.hub.github.app.installId) 0) -}}
+{{- fail "hub.github.app.installId is required (numeric, non-zero). It's the installation ID for the App on your org or repo." -}}
 {{- end -}}
-{{- if and $hasApp (not .Values.hub.github.app.privateKey.secretName) -}}
-{{- fail "hub.github.app: privateKey.secretName is required when app.id and app.installId are set." -}}
+{{- if not .Values.hub.github.app.privateKey.secretName -}}
+{{- fail "hub.github.app.privateKey.secretName is required. Create a Kubernetes secret holding the App's private-key PEM." -}}
 {{- end -}}
 {{- end }}

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -75,18 +75,10 @@ spec:
                 secretKeyRef:
                   name: {{ .github.webhookSecret.secretName }}
                   key: {{ .github.webhookSecret.secretKey }}
-            {{- if .github.token.secretName }}
-            - name: HUB_GITHUB_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .github.token.secretName }}
-                  key: {{ .github.token.secretKey }}
-            {{- end }}
             - name: HUB_GITHUB_SYNC_WINDOW
               value: {{ .github.syncWindow | quote }}
             - name: HUB_GITHUB_BASE_URL
               value: {{ .github.baseUrl | quote }}
-            {{- if include "lunar.hasGitHubApp" $ }}
             - name: HUB_GITHUB_APP_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:
@@ -96,7 +88,6 @@ spec:
               value: {{ .github.app.id | quote }}
             - name: HUB_GITHUB_APP_INSTALL_ID
               value: {{ .github.app.installId | quote }}
-            {{- end }}
             - name: HUB_POLICY_QUEUE_POLL_INTERVAL
               value: {{ .policyQueue.pollInterval | quote }}
             - name: HUB_POLICY_QUEUE_NUM_WORKERS

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -41,11 +41,6 @@ hub:
     webhookSecret:
       secretName: "lunar-github-webhook"
       secretKey: "webhook-secret"
-    # Optional legacy PAT auth. Leave secretName empty when using the GitHub App —
-    # the env var will not be injected. If set, the PAT takes precedence over the App.
-    token:
-      secretName: ""
-      secretKey: "token"
     syncWindow: 2160h
   policyQueue:
     pollInterval: 1s


### PR DESCRIPTION
## Summary

Companion to [lunar#1428](https://github.com/earthly/lunar/pull/1428), which made Hub App-only on the application side. The chart's PAT path is now dead code — set the values, render the env var, Hub won't read it. This PR drops the whole pathway and bumps the chart to **0.5.3**.

## What changes

- **`values.yaml`** — drops the \`hub.github.token\` block.
- **\`hub-deployment.yaml\`** — drops the conditional \`HUB_GITHUB_TOKEN\` env injection and the now-redundant \`if include "lunar.hasGitHubApp"\` guard around the App envs (App is mandatory now).
- **\`_helpers.tpl\`** — collapses \`lunar.githubAuthCheck\` from "exactly one of App or PAT" to "App required" with per-field error messages. Drops the \`hasGitHubApp\` / \`hasGitHubPAT\` helpers (no remaining callers).
- **\`NOTES.txt\`** — drops the conditional GitHub App / PAT secret listings; the App private-key secret is now unconditionally required.
- **\`README.md\`** — rewrites the GitHub authentication section, drops the legacy PAT bullet from optional secrets, and updates the Upgrading-from-0.4.x note to call out the breaking change explicitly.

## Upgrade impact

- **App-auth installs:** No change required.
- **Still-on-PAT installs:** Must install the GitHub App and switch values *before* upgrading. The chart will fail at install time otherwise (validation in \`_helpers.tpl\` enforces App is configured).

We have no customers on PAT auth — this is a breaking change in name only.

## Test plan

- [x] \`helm lint charts/lunar\` passes
- [x] \`helm template\` with App values renders no \`HUB_GITHUB_TOKEN\` env, all App envs present
- [x] Validation fires correctly when \`app.id\` / \`app.installId\` / \`app.privateKey.secretName\` are missing
- [ ] CI green

Made with [Cursor](https://cursor.com)