### PR TITLE
chart: 0.6.1 rename chart-managed secret defaults to drop -hub- segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ After install, retrieve any chart-managed secret with:
 
 ```bash
 # Hub auth token (pass to CLI / CI agents as LUNAR_HUB_TOKEN)
-kubectl -n lunar get secret lunar-hub-auth-token \
+kubectl -n lunar get secret lunar-auth-token \
   -o jsonpath='{.data.token}' | base64 -d
 
 # GitHub webhook secret (register with your GitHub App)
-kubectl -n lunar get secret lunar-hub-github-webhook \
+kubectl -n lunar get secret lunar-github-webhook \
   -o jsonpath='{.data.webhook-secret}' | base64 -d
 ```
 
-(Adjust `lunar-hub-...` for your release name; the actual names are `<release>-hub-auth-token`, `<release>-hub-github-webhook`, `<release>-grafana-admin`.)
+(Adjust `lunar-...` for your release name; the actual names are `<release>-auth-token`, `<release>-github-webhook`, `<release>-grafana-admin`.)
 
 #### GitOps note
 
@@ -214,13 +214,31 @@ helm upgrade lunar earthly/lunar \
   -f values.yaml
 ```
 
+### Upgrading to 0.6.1
+
+0.6.1 renames the chart-managed auto-generated secrets to drop a redundant `-hub-` segment: `<release>-hub-auth-token` → `<release>-auth-token`, `<release>-hub-github-webhook` → `<release>-github-webhook`. Grafana's admin secret is unchanged. If you installed 0.6.0 and let the chart generate these, pick one before upgrading:
+
+- **Keep the old names** — pin `hub.auth.secretName: <release>-hub-auth-token` and `hub.github.webhookSecret.secretName: <release>-hub-github-webhook` in your values. No rename, no rotation.
+- **Migrate to the new names** — copy the existing secret to the new name, then upgrade. Example (from release namespace):
+
+  ```bash
+  kubectl get secret <release>-hub-auth-token -o yaml \
+    | sed 's/<release>-hub-auth-token/<release>-auth-token/' \
+    | kubectl apply -f -
+  kubectl get secret <release>-hub-github-webhook -o yaml \
+    | sed 's/<release>-hub-github-webhook/<release>-github-webhook/' \
+    | kubectl apply -f -
+  ```
+
+  The chart's `lookup` will find the copy and reuse the same token/secret — no agents or webhooks need re-registering. Delete the old secrets once the upgrade is green.
+
 ### Upgrading to 0.6.x
 
 0.6.0 cuts install-time secret bookkeeping and reshapes a few values. There are no in-place data migrations — review these before upgrading:
 
 - **`tenantId` is now required at the top level.** Previously read from `hub.logging.tenantId` and `operator.logging.tenantId` (both removed). Move your value to the top-level `tenantId`. The chart fails install if unset.
 - **Logging and telemetry are now split at the top level for both Hub and Operator.** `hub.logging.*` and `operator.logging.*` are removed. Use `logging.{level,format}` for local process logs and `telemetry.enabled` to enable/disable outbound telemetry shipping for both components together (Elastic settings live at `telemetry.elastic.*`).
-- **Hub auth token, GitHub webhook secret, and Grafana admin credentials are now chart-managed by default.** `hub.auth.secretName`, `hub.github.webhookSecret.secretName`, and `grafana.admin.secretName` default to `""`, in which case the chart generates random values and stores them in `<release>-hub-auth-token`, `<release>-hub-github-webhook`, and `<release>-grafana-admin` (all marked `helm.sh/resource-policy: keep`).
+- **Hub auth token, GitHub webhook secret, and Grafana admin credentials are now chart-managed by default.** `hub.auth.secretName`, `hub.github.webhookSecret.secretName`, and `grafana.admin.secretName` default to `""`, in which case the chart generates random values and stores them in `<release>-auth-token`, `<release>-github-webhook`, and `<release>-grafana-admin` (all marked `helm.sh/resource-policy: keep`).
 
   If you have existing user-managed secrets (`lunar-auth-token`, `lunar-github-webhook`, `lunar-grafana-admin`) and want to keep them, set each `secretName` to the existing name in your values — the chart will reference them and skip auto-generation.
 

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 0.6.0
+version: 0.6.1
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/_helpers.tpl
+++ b/charts/lunar/templates/_helpers.tpl
@@ -99,14 +99,14 @@ Resolved name for the chart-managed Hub auth-token secret.
 Honors hub.auth.secretName when set; otherwise derives from the release.
 */}}
 {{- define "lunar.hubAuthSecretName" -}}
-{{- .Values.hub.auth.secretName | default (printf "%s-hub-auth-token" (include "lunar.fullname" .)) -}}
+{{- .Values.hub.auth.secretName | default (printf "%s-auth-token" (include "lunar.fullname" .)) -}}
 {{- end }}
 
 {{/*
 Resolved name for the chart-managed GitHub webhook secret.
 */}}
 {{- define "lunar.hubWebhookSecretName" -}}
-{{- .Values.hub.github.webhookSecret.secretName | default (printf "%s-hub-github-webhook" (include "lunar.fullname" .)) -}}
+{{- .Values.hub.github.webhookSecret.secretName | default (printf "%s-github-webhook" (include "lunar.fullname" .)) -}}
 {{- end }}
 
 {{/*

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -66,7 +66,7 @@ hub:
     # Webhook secret. Leave secretName empty to have the chart generate one
     # (recommended for fresh installs). The chart-managed secret persists
     # across upgrade and uninstall (helm.sh/resource-policy: keep). Retrieve:
-    #   kubectl get secret <release>-hub-github-webhook \
+    #   kubectl get secret <release>-github-webhook \
     #     -o jsonpath='{.data.webhook-secret}' | base64 -d
     # and register it with your GitHub App.
     #
@@ -101,7 +101,7 @@ hub:
   # Hub auth token. Leave secretName empty to have the chart generate one
   # (recommended for fresh installs). The chart-managed secret persists
   # across upgrade and uninstall (helm.sh/resource-policy: keep). Retrieve:
-  #   kubectl get secret <release>-hub-auth-token \
+  #   kubectl get secret <release>-auth-token \
   #     -o jsonpath='{.data.token}' | base64 -d
   # and pass to CLI / CI agent installs as LUNAR_HUB_TOKEN.
   #


### PR DESCRIPTION
0.6.0 shipped the chart-managed secret path with auto-generated defaults `<release>-hub-auth-token` and `<release>-hub-github-webhook`. The `-hub-` segment is redundant — Lunar's other in-cluster secrets (DB, GitHub App, elastic API key, runtime scope secrets, grafana admin) all use flat `lunar-*` names. Rename the two defaults to match: `<release>-auth-token`, `<release>-github-webhook`. Grafana's default was already clean.

### Changes

- `_helpers.tpl`: rename printf formats in `lunar.hubAuthSecretName` and `lunar.hubWebhookSecretName`.
- `Chart.yaml`: bump to `0.6.1`.
- `values.yaml`: update the two retrieve-command examples in the inline comments.
- `README.md`: update retrieve examples, the generated-names parenthetical, the 0.6.x upgrade bullet, and add a brief "Upgrading to 0.6.1" section with two paths for 0.6.0 adopters (keep-the-old-names via `secretName` pin, or `kubectl | sed | apply` to copy to the new name and let `lookup` reuse the same token).

### Compatibility

Breaking change for anyone who installed 0.6.0 and let the chart auto-generate. 0.6.0 landed <1 day ago so blast radius is near-zero in practice. Anyone who BYO'd `secretName` is unaffected — the rename only changes what the chart emits when `secretName` is empty.

### Verification

`helm template` on the chart with `grafana.enabled=true` now emits:

```
name: lunar-auth-token
name: lunar-github-webhook
name: lunar-grafana-admin
```

`helm lint` passes.