### PR TITLE
chart: 0.7.0 install fixes (Grafana on by default + Hub/Operator Postgres TLS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,19 @@ The central gRPC/HTTP server. Stores metadata, evaluates policies, and serves th
 | `hub.db.user.secretKey` | Key within the secret | `username` |
 | `hub.db.pass.secretName` | Secret containing the DB password | `lunar-db` |
 | `hub.db.pass.secretKey` | Key within the secret | `password` |
+| `hub.db.connectionOptions` | Extra options appended to the Postgres connection string (libpq KV format, space-separated). Default works against managed Postgres with forced TLS (RDS, Aurora, Cloud SQL); set to `"sslmode=disable"` for plain cluster-local Postgres. Also consumed by the operator. | `"sslmode=require"` |
+
+> **Override footgun:** setting `hub.db.connectionOptions` **replaces** the whole string — the default is not merged in. If passing additional options (`connect_timeout`, `application_name`, etc.), include `sslmode=` yourself, space-separated:
+> ```yaml
+> # OK
+> hub:
+>   db:
+>     connectionOptions: "sslmode=require connect_timeout=10"
+> # BAD — silently drops sslmode=require
+> hub:
+>   db:
+>     connectionOptions: "connect_timeout=10"
+> ```
 
 **GitHub**
 

--- a/README.md
+++ b/README.md
@@ -496,11 +496,11 @@ Operator logging uses the top-level global `logging.*` values. Telemetry shippin
 <details>
 <summary><strong>Grafana</strong></summary>
 
-Optional pre-built Grafana instance with dashboards for policy results, component health, and collection activity.
+Pre-built Grafana instance with dashboards for policy results, component health, and collection activity. Deployed by default; set `grafana.enabled: false` to opt out.
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `grafana.enabled` | Deploy the pre-built Grafana instance | `false` |
+| `grafana.enabled` | Deploy the pre-built Grafana instance | `true` |
 | `grafana.image.repository` | Grafana image | `earthly/lunar-grafana` |
 | `grafana.image.tag` | Image tag | `main` |
 | `grafana.admin.secretName` | Secret containing both admin credentials. Empty = chart auto-generates `<release>-grafana-admin` (kept across uninstall) | `""` |

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 0.6.1
+version: 0.7.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -69,6 +69,8 @@ spec:
               value: {{ .db.port | quote }}
             - name: HUB_DB_WAIT_SECS
               value: {{ .db.waitSecs | quote }}
+            - name: HUB_DB_CONNECTION_OPTIONS
+              value: {{ .db.connectionOptions | quote }}
             - name: HUB_DB_MIGRATIONS_PATH
               value: "/usr/share/migrations"
             - name: HUB_GITHUB_WEBHOOK_SECRET

--- a/charts/lunar/templates/operator-deployment.yaml
+++ b/charts/lunar/templates/operator-deployment.yaml
@@ -70,6 +70,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.hub.db.pass.secretName }}
                   key: {{ .Values.hub.db.pass.secretKey }}
+            - name: OPERATOR_DB_CONNECTION_OPTIONS
+              value: {{ .Values.hub.db.connectionOptions | quote }}
             - name: OPERATOR_NAMESPACE
               value: {{ include "lunar.snippetNamespace" . | quote }}
             - name: OPERATOR_MAX_CONCURRENT

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -269,7 +269,7 @@ operator:
   affinity: {}
 
 grafana:
-  enabled: false
+  enabled: true
 
   # Admin credentials. Leave secretName empty to have the chart generate them
   # (recommended for fresh installs): username defaults to "admin", password

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -55,6 +55,22 @@ hub:
     host: ""
     port: 5432
     waitSecs: 45
+    # Extra options appended to the Postgres connection string. Defaults to
+    # sslmode=require so fresh managed-Postgres installs (RDS / Aurora /
+    # Cloud SQL, all of which default to forced TLS) just work. Set to
+    # "sslmode=disable" for plain cluster-local Postgres without TLS.
+    #
+    # Format: libpq KV pairs, space-separated. NOT URL query syntax.
+    #   OK:  "sslmode=require"
+    #   OK:  "sslmode=require connect_timeout=10"
+    #   BAD: "sslmode=require&connect_timeout=10"   # will fail to parse
+    #
+    # Footgun: overriding REPLACES the whole string — the default is not
+    # merged in. If you pass additional options, include sslmode= yourself.
+    #
+    # Also consumed by the operator (OPERATOR_DB_CONNECTION_OPTIONS); both
+    # components connect to the same DB so they share this value.
+    connectionOptions: "sslmode=require"
   github:
     baseUrl: ""
     app:


### PR DESCRIPTION
## Summary

Two related install-friendliness changes bundled under the 0.7.0 chart bump. Both are reviewable independently — one commit each.

### 1. Enable Grafana by default (`4f96b8d`)

Flips `grafana.enabled` from `false` → `true` so the bundled Grafana instance (dashboards for policy results, component health, collection activity) ships out of the box. Operators with a pre-existing observability stack can still opt out with `grafana.enabled: false`.

Behavior change for upgraders: existing installs that do not pin `grafana.enabled` in their `values.yaml` will get a Grafana Deployment, Service, and chart-managed admin Secret on the next `helm upgrade`. The admin secret carries `helm.sh/resource-policy: keep`, so credentials persist across subsequent upgrades and uninstall.

### 2. Expose `hub.db.connectionOptions` for Hub + Operator Postgres TLS (`deb9755`)

Companion to [earthly/lunar#1491](https://github.com/earthly/lunar/pull/1491). Adds a single `hub.db.connectionOptions` value (default `"sslmode=require"`) that maps to both `HUB_DB_CONNECTION_OPTIONS` and `OPERATOR_DB_CONNECTION_OPTIONS`. Unblocks fresh installs against managed Postgres with forced TLS (RDS, Aurora, Cloud SQL all default to `rds.force_ssl=1` in newer regions).

Hub and Operator share the value because they connect to the same DB — matches the existing pattern where the operator already reuses `hub.db.{host,port,name,user,pass}`.

**Format**: libpq KV pairs (space-separated), not URL query syntax, to match the rest of the DSN.

**Footgun**: overriding the value **replaces** the whole string — the default is not merged in. Operators passing additional options must include `sslmode=` themselves; the README and the `values.yaml` comment both call this out.

**Plain-Postgres migration**: deployments on cluster-local plain Postgres must set `hub.db.connectionOptions: "sslmode=disable"` **before** upgrading the image, otherwise Hub and Operator will crash-loop trying to negotiate TLS.

## Test plan

- [x] `helm template` with defaults renders `HUB_DB_CONNECTION_OPTIONS=sslmode=require` and `OPERATOR_DB_CONNECTION_OPTIONS=sslmode=require`.
- [x] `helm template` with `hub.db.connectionOptions=sslmode=disable` renders that exact string on both env vars.
- [x] `helm lint` clean.
- [ ] Fresh install against RDS Postgres 16 with default `rds.force_ssl=1` succeeds (paired with earthly/lunar#1491 landing).
- [ ] Existing install against plain Postgres works after setting `hub.db.connectionOptions: "sslmode=disable"`.


Made with [Cursor](https://cursor.com)