### PR TITLE
chart: 0.8.2 default hub DNS to cross-namespace FQDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Run `helm show values earthly/lunar` for the full, authoritative list. Defaults 
 |-----|-------------|---------|
 | `nameOverride` | Override the chart name | `""` |
 | `fullnameOverride` | Override the full release name | `""` |
+| `clusterDomain` | Kubernetes cluster DNS domain. Override only if your cluster was provisioned with a non-default `--cluster-domain` | `cluster.local` |
 | `logging.level` | Log level (`debug`, `info`, `warn`, `error`) applied to both Hub and Operator | `info` |
 | `logging.format` | Log format (`json` or `text`) applied to both Hub and Operator | `json` |
 | `imagePullSecrets` | Image pull secrets for all pods | `[]` |
@@ -433,6 +434,7 @@ Watches for snippet execution jobs and creates Kubernetes pods to run them.
 | Key | Description | Default |
 |-----|-------------|---------|
 | `operator.snippetNamespace` | Namespace for snippet pods (must exist if set) | `""` (release namespace) |
+| `operator.hubHost` | Override hostname the operator and snippet pods use to reach Hub gRPC. Empty = computed in-cluster FQDN, which resolves cross-namespace. Set only for service-mesh / split-DNS / multi-cluster topologies | `""` |
 | `operator.maxConcurrent` | Max concurrent snippet pods | `10` |
 | `operator.healthPort` | Operator health check port | `8081` |
 | `operator.extraEnv` | Additional environment variables | `[]` |

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 0.8.1
+version: 0.8.2
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/_helpers.tpl
+++ b/charts/lunar/templates/_helpers.tpl
@@ -119,3 +119,13 @@ Resolved name for the chart-managed Grafana admin secret.
 {{- define "lunar.grafanaAdminSecretName" -}}
 {{- .Values.grafana.admin.secretName | default (printf "%s-grafana-admin" (include "lunar.fullname" .)) -}}
 {{- end }}
+
+{{/*
+In-cluster DNS name for the Hub service, in `<svc>.<ns>.svc.<clusterDomain>`
+form so it resolves from any namespace (the operator's snippetNamespace, in
+particular). Callers that need to honor a per-component override should do
+`default (include "lunar.hubHost" .) .Values.<component>.hubHost`.
+*/}}
+{{- define "lunar.hubHost" -}}
+{{- printf "%s-hub.%s.svc.%s" (include "lunar.fullname" .) .Release.Namespace .Values.clusterDomain -}}
+{{- end }}

--- a/charts/lunar/templates/grafana-deployment.yaml
+++ b/charts/lunar/templates/grafana-deployment.yaml
@@ -60,7 +60,7 @@ spec:
             - name: POSTGRES_DB
               value: {{ $.Values.hub.db.name | quote }}
             - name: LUNAR_HUB_HOST
-              value: {{ include "lunar.fullname" $ }}-hub
+              value: {{ include "lunar.hubHost" $ | quote }}
             - name: LUNAR_HUB_HTTP_PORT
               value: {{ $.Values.hub.service.ports.http | quote }}
             {{- if $.Values.hub.publicBaseURL }}

--- a/charts/lunar/templates/operator-deployment.yaml
+++ b/charts/lunar/templates/operator-deployment.yaml
@@ -87,7 +87,7 @@ spec:
             - name: OPERATOR_SIDECAR_IMAGE
               value: "{{ .Values.operator.sidecarImage.repository }}:{{ .Values.operator.sidecarImage.tag | default .Chart.AppVersion }}"
             - name: OPERATOR_HUB_HOST
-              value: {{ include "lunar.fullname" . }}-hub
+              value: {{ .Values.operator.hubHost | default (include "lunar.hubHost" .) | quote }}
             - name: OPERATOR_HUB_GRPC_PORT
               value: {{ .Values.hub.service.ports.server | quote }}
             - name: OPERATOR_HUB_HTTP_PORT

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -2,6 +2,12 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# Kubernetes cluster DNS domain. Used to render in-cluster service FQDNs
+# (`<svc>.<ns>.svc.<clusterDomain>`). Default matches stock K8s. Override only
+# if your cluster was provisioned with a non-default --cluster-domain (rare;
+# most managed clusters — EKS, GKE, AKS — use cluster.local).
+clusterDomain: cluster.local
+
 imagePullSecrets: []
 
 # Global logger config applied to both Hub and Operator.
@@ -227,6 +233,16 @@ operator:
   # Namespace where snippet pods are created. Defaults to the release namespace.
   # If set, the namespace must already exist — the chart will not create it.
   snippetNamespace: ""
+
+  # Hostname the operator (and the snippet pods it spawns) uses to reach Hub
+  # gRPC. Empty = chart computes the in-cluster FQDN
+  # `<release>-hub.<release-namespace>.svc.<clusterDomain>`, which resolves
+  # from any namespace and is the right answer for ~all installs (including
+  # cross-namespace `snippetNamespace`). Override only for service-mesh /
+  # split-DNS / multi-cluster topologies where Hub is reachable at a
+  # non-standard name.
+  hubHost: ""
+
   maxConcurrent: 10
   healthPort: 8081
 


### PR DESCRIPTION
## Summary

- Renders hub DNS as `<release>-hub.<ns>.svc.<clusterDomain>` by default (in both the operator and Grafana deployments), so the in-cluster name resolves from any namespace — including a separate `operator.snippetNamespace`. Matches the Bitnami / kube-prometheus-stack convention.
- Adds top-level `clusterDomain: cluster.local` and `operator.hubHost: ""` override hatch (for service-mesh / split-DNS / multi-cluster edge cases).
- Supersedes the `bender/eng-704-operator-hubhost` branch, which addressed the same root cause by exposing the override only — leaving the broken default in place.

## Why

Old default was the short name `<release>-hub`, which only resolves inside Hub's namespace. Operators with a separate `operator.snippetNamespace` worked around it by re-defining `OPERATOR_HUB_HOST` via `operator.extraEnv`. That works at runtime but produces a duplicate-env warning from the API server, and every subsequent `helm upgrade --reuse-values` fails with `"The order in patch list doesn't match \$setElementOrder list"` once strategic-merge sees the env-list reorder.

Fixing the default fixes the bug for everyone without requiring them to know an override knob exists.

## Upgrade note for existing installs

Operators who added `OPERATOR_HUB_HOST` to `operator.extraEnv` as the cross-namespace workaround should remove that entry after upgrading. The new default already resolves correctly cross-namespace; leaving the workaround in place keeps the duplicate-env warning (and the broken-upgrade footgun) intact.

## Test plan

- [x] `helm lint charts/lunar` clean
- [x] `helm template` with defaults: both consumers render `<release>-hub.<ns>.svc.cluster.local`
- [x] `helm template --set clusterDomain=cluster.example`: both consumers pick up the custom domain
- [x] `helm template --set operator.hubHost=hub-internal.mesh.example`: operator takes the override verbatim, Grafana still uses computed FQDN
- [x] Operator container env count unchanged (19), no duplicates, `OPERATOR_HUB_HOST` still at index 13 (no movement → strategic-merge-friendly upgrades from 0.8.1)
- [ ] Smoke-deploy 0.8.2 to a cluster with `operator.snippetNamespace` ≠ release namespace and confirm snippet pods successfully reach Hub

Made with [Cursor](https://cursor.com)