### PR TITLE
chart: 1.0.1 — fix image tag pin (2.1.1, not v2.1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ The central gRPC/HTTP server. Stores metadata, evaluates policies, and serves th
 | Key | Description | Default |
 |-----|-------------|---------|
 | `hub.image.repository` | Hub container image | `ghcr.io/earthly/lunar-hub` |
-| `hub.image.tag` | Image tag | `v2.1.1` |
+| `hub.image.tag` | Image tag | `2.1.1` |
 | `hub.image.pullPolicy` | Pull policy | `IfNotPresent` |
 | `hub.extraEnv` | Additional environment variables (`name`/`value` or `valueFrom` pairs) | `[]` |
 
@@ -422,12 +422,12 @@ Watches for script execution jobs and creates Kubernetes pods to run them.
 | Key | Description | Default |
 |-----|-------------|---------|
 | `operator.image.repository` | Operator image | `ghcr.io/earthly/lunar-snippet-operator` |
-| `operator.image.tag` | Image tag | `v2.1.1` |
+| `operator.image.tag` | Image tag | `2.1.1` |
 | `operator.image.pullPolicy` | Pull policy | `IfNotPresent` |
 | `operator.initImage.repository` | Init container image | `ghcr.io/earthly/lunar-snippet-init` |
-| `operator.initImage.tag` | Image tag | `v2.1.1` |
+| `operator.initImage.tag` | Image tag | `2.1.1` |
 | `operator.sidecarImage.repository` | Sidecar container image | `ghcr.io/earthly/lunar-snippet-sidecar` |
-| `operator.sidecarImage.tag` | Image tag | `v2.1.1` |
+| `operator.sidecarImage.tag` | Image tag | `2.1.1` |
 
 **Behavior**
 
@@ -480,7 +480,7 @@ Pre-built Grafana instance with dashboards for policy results, component health,
 |-----|-------------|---------|
 | `grafana.enabled` | Deploy the pre-built Grafana instance | `true` |
 | `grafana.image.repository` | Grafana image | `ghcr.io/earthly/lunar-grafana` |
-| `grafana.image.tag` | Image tag | `v2.1.1` |
+| `grafana.image.tag` | Image tag | `2.1.1` |
 | `grafana.admin.secretName` | Secret containing both admin credentials. Empty = chart auto-generates `<release>-grafana-admin` (kept across uninstall) | `""` |
 | `grafana.admin.userKey` | Key within the secret holding the username | `username` |
 | `grafana.admin.passwordKey` | Key within the secret holding the password | `password` |

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 1.0.0
+version: 1.0.1
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -161,7 +161,7 @@ hub:
   image:
     repository: "ghcr.io/earthly/lunar-hub"
     pullPolicy: IfNotPresent
-    tag: "v2.1.1"
+    tag: "2.1.1"
 
   service:
     type: ClusterIP
@@ -218,17 +218,17 @@ operator:
   image:
     repository: "ghcr.io/earthly/lunar-snippet-operator"
     pullPolicy: IfNotPresent
-    tag: "v2.1.1"
+    tag: "2.1.1"
 
   initImage:
     repository: "ghcr.io/earthly/lunar-snippet-init"
     pullPolicy: IfNotPresent
-    tag: "v2.1.1"
+    tag: "2.1.1"
 
   sidecarImage:
     repository: "ghcr.io/earthly/lunar-snippet-sidecar"
     pullPolicy: IfNotPresent
-    tag: "v2.1.1"
+    tag: "2.1.1"
 
   # Namespace where script pods are created. Defaults to the release namespace.
   # If set, the namespace must already exist — the chart will not create it.
@@ -323,7 +323,7 @@ grafana:
   image:
     repository: "ghcr.io/earthly/lunar-grafana"
     pullPolicy: IfNotPresent
-    tag: "v2.1.1"
+    tag: "2.1.1"
 
   service:
     type: ClusterIP


### PR DESCRIPTION
## Summary

- The image tags published for hub/operator/grafana are `2.1.1`, not `v2.1.1`. `lunar-1.0.0` is currently broken — image pulls 404.
- Replaces `v2.1.1` → `2.1.1` across `charts/lunar/values.yaml` (5 occurrences) and the defaults table in `README.md` (5 occurrences).
- Bumps chart version `1.0.0` → `1.0.1` so chart-releaser actually publishes the fix.

## Test plan

- [ ] `helm template charts/lunar` renders with the corrected tags
- [ ] `helm install` against a real cluster successfully pulls images
- [ ] chart-releaser publishes `lunar-1.0.1` on merge to `main`


Made with [Cursor](https://cursor.com)