### PR TITLE
Add Lunar worker chart settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ The central gRPC/HTTP server. Stores metadata, evaluates policies, and serves th
 | `hub.image.repository` | Hub container image | `ghcr.io/earthly/lunar-hub` |
 | `hub.image.tag` | Image tag | `2.1.1` |
 | `hub.image.pullPolicy` | Pull policy | `IfNotPresent` |
-| `hub.maxWorkers.collect` | Max Hub workers for collector queue jobs | `10` |
-| `hub.maxWorkers.policy` | Max Hub workers for policy queue jobs | `20` |
-| `hub.maxWorkers.cronCollect` | Max Hub workers for cron collector queue jobs | `5` |
-| `hub.maxWorkers.cataloger` | Max Hub workers for cataloger queue jobs | `1` |
+| `hub.maxWorkers.collect` | Max Hub workers for collector queue jobs; `0` means unlimited | `0` |
+| `hub.maxWorkers.policy` | Max Hub workers for policy queue jobs; `0` means unlimited | `0` |
+| `hub.maxWorkers.cronCollect` | Max Hub workers for cron collector queue jobs; `0` means unlimited | `0` |
+| `hub.maxWorkers.cataloger` | Max Hub workers for cataloger queue jobs; `0` means unlimited | `0` |
 | `hub.extraEnv` | Additional environment variables (`name`/`value` or `valueFrom` pairs) | `[]` |
 
 **Public URL**

--- a/README.md
+++ b/README.md
@@ -257,6 +257,11 @@ The central gRPC/HTTP server. Stores metadata, evaluates policies, and serves th
 | `hub.image.repository` | Hub container image | `ghcr.io/earthly/lunar-hub` |
 | `hub.image.tag` | Image tag | `2.1.1` |
 | `hub.image.pullPolicy` | Pull policy | `IfNotPresent` |
+| `hub.maxWorkers.collect` | Max Hub workers for collector queue jobs | `10` |
+| `hub.maxWorkers.policy` | Max Hub workers for policy queue jobs | `20` |
+| `hub.maxWorkers.cronCollect` | Max Hub workers for cron collector queue jobs | `5` |
+| `hub.maxWorkers.cataloger` | Max Hub workers for cataloger queue jobs | `1` |
+| `hub.maxOperatorPoolSize` | Max Hub Postgres connections for operator queue work | `5` |
 | `hub.extraEnv` | Additional environment variables (`name`/`value` or `valueFrom` pairs) | `[]` |
 
 **Public URL**
@@ -436,6 +441,7 @@ Watches for script execution jobs and creates Kubernetes pods to run them.
 | `operator.scriptNamespace` | Namespace for script pods (must exist if set) | `""` (release namespace) |
 | `operator.hubHost` | Override hostname the operator and script pods use to reach Hub gRPC. Empty = computed in-cluster FQDN, which resolves cross-namespace. Set only for service-mesh / split-DNS / multi-cluster topologies | `""` |
 | `operator.maxConcurrent` | Max concurrent script pods | `10` |
+| `operator.maxPoolSize` | Max operator Postgres pool size | `5` |
 | `operator.healthPort` | Operator health check port | `8081` |
 | `operator.extraEnv` | Additional environment variables | `[]` |
 

--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ The central gRPC/HTTP server. Stores metadata, evaluates policies, and serves th
 | `hub.image.repository` | Hub container image | `ghcr.io/earthly/lunar-hub` |
 | `hub.image.tag` | Image tag | `2.1.1` |
 | `hub.image.pullPolicy` | Pull policy | `IfNotPresent` |
-| `hub.maxWorkers.collect` | Max Hub workers for collector queue jobs; `0` means unlimited | `0` |
-| `hub.maxWorkers.policy` | Max Hub workers for policy queue jobs; `0` means unlimited | `0` |
-| `hub.maxWorkers.cronCollect` | Max Hub workers for cron collector queue jobs; `0` means unlimited | `0` |
-| `hub.maxWorkers.cataloger` | Max Hub workers for cataloger queue jobs; `0` means unlimited | `0` |
+| `hub.maxWorkers.collect` | Max Hub workers for collector queue jobs; `0` means unlimited | `10` |
+| `hub.maxWorkers.policy` | Max Hub workers for policy queue jobs; `0` means unlimited | `20` |
+| `hub.maxWorkers.cronCollect` | Max Hub workers for cron collector queue jobs; `0` means unlimited | `5` |
+| `hub.maxWorkers.cataloger` | Max Hub workers for cataloger queue jobs; `0` means unlimited | `1` |
 | `hub.extraEnv` | Additional environment variables (`name`/`value` or `valueFrom` pairs) | `[]` |
 
 **Public URL**

--- a/README.md
+++ b/README.md
@@ -261,7 +261,6 @@ The central gRPC/HTTP server. Stores metadata, evaluates policies, and serves th
 | `hub.maxWorkers.policy` | Max Hub workers for policy queue jobs | `20` |
 | `hub.maxWorkers.cronCollect` | Max Hub workers for cron collector queue jobs | `5` |
 | `hub.maxWorkers.cataloger` | Max Hub workers for cataloger queue jobs | `1` |
-| `hub.maxOperatorPoolSize` | Max Hub Postgres connections for operator queue work | `5` |
 | `hub.extraEnv` | Additional environment variables (`name`/`value` or `valueFrom` pairs) | `[]` |
 
 **Public URL**
@@ -441,7 +440,6 @@ Watches for script execution jobs and creates Kubernetes pods to run them.
 | `operator.scriptNamespace` | Namespace for script pods (must exist if set) | `""` (release namespace) |
 | `operator.hubHost` | Override hostname the operator and script pods use to reach Hub gRPC. Empty = computed in-cluster FQDN, which resolves cross-namespace. Set only for service-mesh / split-DNS / multi-cluster topologies | `""` |
 | `operator.maxConcurrent` | Max concurrent script pods | `10` |
-| `operator.maxPoolSize` | Max operator Postgres pool size | `5` |
 | `operator.healthPort` | Operator health check port | `8081` |
 | `operator.extraEnv` | Additional environment variables | `[]` |
 

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 1.0.1
+version: 1.0.2
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -153,8 +153,6 @@ spec:
               value: {{ .maxWorkers.cronCollect | quote }}
             - name: HUB_MAX_WORKERS_CATALOGER
               value: {{ .maxWorkers.cataloger | quote }}
-            - name: HUB_MAX_OPERATOR_POOL_SIZE
-              value: {{ .maxOperatorPoolSize | quote }}
             {{- with .extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -145,6 +145,16 @@ spec:
             {{- end }}
             - name: HUB_K8S_EXECUTION_ENABLED
               value: "true"
+            - name: HUB_MAX_WORKERS_COLLECT
+              value: {{ .maxWorkers.collect | quote }}
+            - name: HUB_MAX_WORKERS_POLICY
+              value: {{ .maxWorkers.policy | quote }}
+            - name: HUB_MAX_WORKERS_CRON_COLLECT
+              value: {{ .maxWorkers.cronCollect | quote }}
+            - name: HUB_MAX_WORKERS_CATALOGER
+              value: {{ .maxWorkers.cataloger | quote }}
+            - name: HUB_MAX_OPERATOR_POOL_SIZE
+              value: {{ .maxOperatorPoolSize | quote }}
             {{- with .extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/lunar/templates/operator-deployment.yaml
+++ b/charts/lunar/templates/operator-deployment.yaml
@@ -76,8 +76,6 @@ spec:
               value: {{ include "lunar.scriptNamespace" . | quote }}
             - name: OPERATOR_MAX_CONCURRENT
               value: {{ .Values.operator.maxConcurrent | quote }}
-            - name: OPERATOR_MAX_POOL_SIZE
-              value: {{ .Values.operator.maxPoolSize | quote }}
             - name: OPERATOR_HEALTH_PORT
               value: {{ .Values.operator.healthPort | quote }}
             - name: LUNAR_LOG_LEVEL

--- a/charts/lunar/templates/operator-deployment.yaml
+++ b/charts/lunar/templates/operator-deployment.yaml
@@ -76,6 +76,8 @@ spec:
               value: {{ include "lunar.scriptNamespace" . | quote }}
             - name: OPERATOR_MAX_CONCURRENT
               value: {{ .Values.operator.maxConcurrent | quote }}
+            - name: OPERATOR_MAX_POOL_SIZE
+              value: {{ .Values.operator.maxPoolSize | quote }}
             - name: OPERATOR_HEALTH_PORT
               value: {{ .Values.operator.healthPort | quote }}
             - name: LUNAR_LOG_LEVEL

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -106,8 +106,6 @@ hub:
     policy: 20
     cronCollect: 5
     cataloger: 1
-  maxOperatorPoolSize: 5
-
   # S3-compatible object storage for script logs and resource archives.
   # The buckets must exist and be writable by the hub's AWS credentials.
   # AWS credentials themselves are intentionally out of scope for this
@@ -254,7 +252,6 @@ operator:
   hubHost: ""
 
   maxConcurrent: 10
-  maxPoolSize: 5
   healthPort: 8081
 
   # Per-script-type base container spec. The operator overlays required

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -101,10 +101,10 @@ hub:
 
   # Worker caps for Hub's script-feeding queues. 0 means unlimited.
   maxWorkers:
-    collect: 0
-    policy: 0
-    cronCollect: 0
-    cataloger: 0
+    collect: 10
+    policy: 20
+    cronCollect: 5
+    cataloger: 1
   # S3-compatible object storage for script logs and resource archives.
   # The buckets must exist and be writable by the hub's AWS credentials.
   # AWS credentials themselves are intentionally out of scope for this

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -98,6 +98,16 @@ hub:
   policyQueue:
     pollInterval: 1s
     numWorkers: 5
+
+  # Worker and pool caps for Hub's script-feeding queues. These should be
+  # increased alongside operator.maxConcurrent when scaling script execution.
+  maxWorkers:
+    collect: 10
+    policy: 20
+    cronCollect: 5
+    cataloger: 1
+  maxOperatorPoolSize: 5
+
   # S3-compatible object storage for script logs and resource archives.
   # The buckets must exist and be writable by the hub's AWS credentials.
   # AWS credentials themselves are intentionally out of scope for this
@@ -244,6 +254,7 @@ operator:
   hubHost: ""
 
   maxConcurrent: 10
+  maxPoolSize: 5
   healthPort: 8081
 
   # Per-script-type base container spec. The operator overlays required

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -99,13 +99,12 @@ hub:
     pollInterval: 1s
     numWorkers: 5
 
-  # Worker and pool caps for Hub's script-feeding queues. These should be
-  # increased alongside operator.maxConcurrent when scaling script execution.
+  # Worker caps for Hub's script-feeding queues. 0 means unlimited.
   maxWorkers:
-    collect: 10
-    policy: 20
-    cronCollect: 5
-    cataloger: 1
+    collect: 0
+    policy: 0
+    cronCollect: 0
+    cataloger: 0
   # S3-compatible object storage for script logs and resource archives.
   # The buckets must exist and be writable by the hub's AWS credentials.
   # AWS credentials themselves are intentionally out of scope for this


### PR DESCRIPTION
## Summary
- add first-class Hub worker and operator pool chart values
- wire those values to the existing Hub/operator env vars
- document the new settings and bump the chart to 1.0.2

## Validation
- helm lint charts/lunar
- helm template lunar charts/lunar --set hub.github.app.id=1 --set hub.github.app.installId=1 --set hub.db.host=db.example --set hub.db.passwordSecret.name=db-secret --set hub.db.passwordSecret.key=password