### PR TITLE
[ENG-611] Add multi-App GitHub auth support to lunar chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Plus two URL prerequisites the chart needs to wire correctly:
 
 Hub authenticates to GitHub as a GitHub App. Two modes, mutually exclusive:
 
-- **Single-App (default).** Set `hub.github.app.id` + `hub.github.app.installId` and create the `lunar-github-app` Secret holding the App's private-key PEM. Suitable for single-tenant deployments where the Hub fronts one App installed in one org.
+- **Single-App (default).** Set `hub.github.app.owner` (the GitHub org or user the App is installed on), `hub.github.app.id`, and `hub.github.app.installId`, then create the `lunar-github-app` Secret holding the App's private-key PEM. Suitable for single-tenant deployments where the Hub fronts one App installed in one org. **Breaking change in 3.0.0:** `hub.github.app.owner` is now required — prior chart versions inferred a default routing internally; the Hub now requires the value explicitly via `HUB_GITHUB_APP_OWNER`.
 
 - **Multi-App.** Use this when the Hub serves multiple orgs that each install their own Lunar App. List one entry per owner under `hub.github.apps`, and put all the PEM files in a single Kubernetes Secret named via `hub.github.appsSecret.secretName`. The chart looks up each entry's PEM at `<lowercase-owner>.pem` inside that Secret.
 
@@ -502,6 +502,7 @@ Hub authenticates as a GitHub App. App ID, install ID, and the App's private-key
 
 | Key | Description | Default |
 |-----|-------------|---------|
+| `hub.github.app.owner` | GitHub org or user the App is installed on (single-App mode) **(required as of 3.0.0)** | `""` |
 | `hub.github.app.id` | GitHub App ID (single-App mode) | `0` |
 | `hub.github.app.installId` | GitHub App Installation ID (single-App mode) | `0` |
 | `hub.github.app.privateKey.secretName` | Secret containing the App private-key PEM (single-App mode) | `lunar-github-app` |

--- a/README.md
+++ b/README.md
@@ -114,7 +114,35 @@ Plus two URL prerequisites the chart needs to wire correctly:
 
 ### GitHub authentication
 
-Hub authenticates to GitHub as a GitHub App. Set `hub.github.app.id` + `hub.github.app.installId` and create the `lunar-github-app` secret holding the App's private-key PEM. The chart validates these at install time with `helm.sh/fail`.
+Hub authenticates to GitHub as a GitHub App. Two modes, mutually exclusive:
+
+- **Single-App (default).** Set `hub.github.app.id` + `hub.github.app.installId` and create the `lunar-github-app` Secret holding the App's private-key PEM. Suitable for single-tenant deployments where the Hub fronts one App installed in one org.
+
+- **Multi-App.** Use this when the Hub serves multiple orgs that each install their own Lunar App. List one entry per owner under `hub.github.apps`, and put all the PEM files in a single Kubernetes Secret named via `hub.github.appsSecret.secretName`. The chart looks up each entry's PEM at `<lowercase-owner>.pem` inside that Secret.
+
+  ```yaml
+  hub:
+    github:
+      apps:
+        - owner: earthly
+          appId: 123
+          installId: 100
+        - owner: acme
+          appId: 456
+          installId: 200
+      appsSecret:
+        secretName: lunar-github-apps
+  ```
+
+  Create the Secret out of band:
+
+  ```bash
+  kubectl create secret generic lunar-github-apps \
+    --from-file=earthly.pem=./earthly.pem \
+    --from-file=acme.pem=./acme.pem
+  ```
+
+The chart validates the chosen mode at install time with `helm.sh/fail` (mutex, required fields, duplicate owners).
 
 ### Object storage & AWS credentials
 
@@ -474,10 +502,12 @@ Hub authenticates as a GitHub App. App ID, install ID, and the App's private-key
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `hub.github.app.id` | GitHub App ID | `0` **(required)** |
-| `hub.github.app.installId` | GitHub App Installation ID | `0` **(required)** |
-| `hub.github.app.privateKey.secretName` | Secret containing the App private-key PEM | `lunar-github-app` |
+| `hub.github.app.id` | GitHub App ID (single-App mode) | `0` |
+| `hub.github.app.installId` | GitHub App Installation ID (single-App mode) | `0` |
+| `hub.github.app.privateKey.secretName` | Secret containing the App private-key PEM (single-App mode) | `lunar-github-app` |
 | `hub.github.app.privateKey.secretKey` | Key within the secret | `private-key` |
+| `hub.github.apps` | Multi-App entries: list of `{owner, appId, installId}`. Mutually exclusive with `hub.github.app.*`. | `[]` |
+| `hub.github.appsSecret.secretName` | Secret holding one PEM key per `apps[].owner` (key name: `<lowercase-owner>.pem`) | `lunar-github-apps` |
 | `hub.github.webhookSecret.secretName` | Secret containing the webhook secret | `lunar-github-webhook` |
 | `hub.github.webhookSecret.secretKey` | Key within the secret | `webhook-secret` |
 | `hub.github.baseUrl` | GitHub API base URL (for GitHub Enterprise Server) | `""` |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Plus two URL prerequisites the chart needs to wire correctly:
 
 Hub authenticates to GitHub as a GitHub App. Two modes, mutually exclusive:
 
-- **Single-App (default).** Set `hub.github.app.owner` (the GitHub org or user the App is installed on), `hub.github.app.id`, and `hub.github.app.installId`, then create the `lunar-github-app` Secret holding the App's private-key PEM. Suitable for single-tenant deployments where the Hub fronts one App installed in one org. **Required as of 2.1.0:** `hub.github.app.owner` is now required — prior chart versions inferred a default routing internally; the Hub now requires the value explicitly via `HUB_GITHUB_APP_OWNER`.
+- **Single-App (default).** Set `hub.github.app.owner` (the GitHub org or user the App is installed on), `hub.github.app.id`, and `hub.github.app.installId`, then create the `lunar-github-app` Secret holding the App's private-key PEM. Suitable for single-tenant deployments where the Hub fronts one App installed in one org. **Required as of 2.2.0:** `hub.github.app.owner` is now required — prior chart versions inferred a default routing internally; the Hub now requires the value explicitly via `HUB_GITHUB_APP_OWNER`.
 
 - **Multi-App.** Use this when the Hub serves multiple orgs that each install their own Lunar App. List one entry per owner under `hub.github.apps`, and put all the PEM files in a single Kubernetes Secret named via `hub.github.appsSecret.secretName`. The chart looks up each entry's PEM at `<lowercase-owner>.pem` inside that Secret.
 
@@ -502,7 +502,7 @@ Hub authenticates as a GitHub App. App ID, install ID, and the App's private-key
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `hub.github.app.owner` | GitHub org or user the App is installed on (single-App mode) **(required as of 2.1.0)** | `""` |
+| `hub.github.app.owner` | GitHub org or user the App is installed on (single-App mode) **(required as of 2.2.0)** | `""` |
 | `hub.github.app.id` | GitHub App ID (single-App mode) | `0` |
 | `hub.github.app.installId` | GitHub App Installation ID (single-App mode) | `0` |
 | `hub.github.app.privateKey.secretName` | Secret containing the App private-key PEM (single-App mode) | `lunar-github-app` |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Plus two URL prerequisites the chart needs to wire correctly:
 
 Hub authenticates to GitHub as a GitHub App. Two modes, mutually exclusive:
 
-- **Single-App (default).** Set `hub.github.app.owner` (the GitHub org or user the App is installed on), `hub.github.app.id`, and `hub.github.app.installId`, then create the `lunar-github-app` Secret holding the App's private-key PEM. Suitable for single-tenant deployments where the Hub fronts one App installed in one org. **Breaking change in 3.0.0:** `hub.github.app.owner` is now required — prior chart versions inferred a default routing internally; the Hub now requires the value explicitly via `HUB_GITHUB_APP_OWNER`.
+- **Single-App (default).** Set `hub.github.app.owner` (the GitHub org or user the App is installed on), `hub.github.app.id`, and `hub.github.app.installId`, then create the `lunar-github-app` Secret holding the App's private-key PEM. Suitable for single-tenant deployments where the Hub fronts one App installed in one org. **Required as of 2.1.0:** `hub.github.app.owner` is now required — prior chart versions inferred a default routing internally; the Hub now requires the value explicitly via `HUB_GITHUB_APP_OWNER`.
 
 - **Multi-App.** Use this when the Hub serves multiple orgs that each install their own Lunar App. List one entry per owner under `hub.github.apps`, and put all the PEM files in a single Kubernetes Secret named via `hub.github.appsSecret.secretName`. The chart looks up each entry's PEM at `<lowercase-owner>.pem` inside that Secret.
 
@@ -502,7 +502,7 @@ Hub authenticates as a GitHub App. App ID, install ID, and the App's private-key
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `hub.github.app.owner` | GitHub org or user the App is installed on (single-App mode) **(required as of 3.0.0)** | `""` |
+| `hub.github.app.owner` | GitHub org or user the App is installed on (single-App mode) **(required as of 2.1.0)** | `""` |
 | `hub.github.app.id` | GitHub App ID (single-App mode) | `0` |
 | `hub.github.app.installId` | GitHub App Installation ID (single-App mode) | `0` |
 | `hub.github.app.privateKey.secretName` | Secret containing the App private-key PEM (single-App mode) | `lunar-github-app` |

--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,6 +9,19 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
+## [2.2.0] - 2026-05-26
+
+### Added
+
+- Multi-App GitHub auth. New `hub.github.apps` list pairs each
+  `{owner, appId, installId}` with a per-owner PEM in an
+  operator-managed Secret referenced by `hub.github.appsSecret`.
+  In multi-App mode the chart renders `HUB_GITHUB_APPS` JSON and
+  mounts the Secret at `/secrets/github-apps`. The legacy
+  `hub.github.app.*` single-App configuration is unchanged and
+  remains supported; render-time validation enforces mutual
+  exclusivity between the two modes.
+
 ## [2.1.0] - 2026-05-25
 
 ### Added

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 2.1.0
+version: 2.2.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/_helpers.tpl
+++ b/charts/lunar/templates/_helpers.tpl
@@ -87,7 +87,7 @@ Fail fast when GitHub App auth is misconfigured.
 {{- fail "hub.github.app.privateKey.secretName is required. Create a Kubernetes secret holding the App's private-key PEM." -}}
 {{- end -}}
 {{- if not .Values.hub.github.app.owner -}}
-{{- fail "hub.github.app.owner is required (chart >= 3.0.0). It's the GitHub org or user the App is installed on. Operators upgrading from chart < 3.0.0 must set this; the Hub now requires HUB_GITHUB_APP_OWNER to route webhooks." -}}
+{{- fail "hub.github.app.owner is required (chart >= 2.1.0). It's the GitHub org or user the App is installed on. Operators upgrading from chart < 2.1.0 must set this; the Hub now requires HUB_GITHUB_APP_OWNER to route webhooks." -}}
 {{- end -}}
 {{- end -}}
 {{- end }}

--- a/charts/lunar/templates/_helpers.tpl
+++ b/charts/lunar/templates/_helpers.tpl
@@ -86,6 +86,9 @@ Fail fast when GitHub App auth is misconfigured.
 {{- if not .Values.hub.github.app.privateKey.secretName -}}
 {{- fail "hub.github.app.privateKey.secretName is required. Create a Kubernetes secret holding the App's private-key PEM." -}}
 {{- end -}}
+{{- if not .Values.hub.github.app.owner -}}
+{{- fail "hub.github.app.owner is required (chart >= 3.0.0). It's the GitHub org or user the App is installed on. Operators upgrading from chart < 3.0.0 must set this; the Hub now requires HUB_GITHUB_APP_OWNER to route webhooks." -}}
+{{- end -}}
 {{- end -}}
 {{- end }}
 

--- a/charts/lunar/templates/_helpers.tpl
+++ b/charts/lunar/templates/_helpers.tpl
@@ -87,7 +87,7 @@ Fail fast when GitHub App auth is misconfigured.
 {{- fail "hub.github.app.privateKey.secretName is required. Create a Kubernetes secret holding the App's private-key PEM." -}}
 {{- end -}}
 {{- if not .Values.hub.github.app.owner -}}
-{{- fail "hub.github.app.owner is required (chart >= 2.1.0). It's the GitHub org or user the App is installed on. Operators upgrading from chart < 2.1.0 must set this; the Hub now requires HUB_GITHUB_APP_OWNER to route webhooks." -}}
+{{- fail "hub.github.app.owner is required (chart >= 2.2.0). It's the GitHub org or user the App is installed on. Operators upgrading from chart < 2.2.0 must set this; the Hub now requires HUB_GITHUB_APP_OWNER to route webhooks." -}}
 {{- end -}}
 {{- end -}}
 {{- end }}

--- a/charts/lunar/templates/_helpers.tpl
+++ b/charts/lunar/templates/_helpers.tpl
@@ -69,8 +69,16 @@ Namespace where script pods run. Defaults to the release namespace.
 Fail fast when GitHub App auth is misconfigured.
 */}}
 {{- define "lunar.githubAuthCheck" -}}
+{{- $hasApps := gt (len .Values.hub.github.apps) 0 -}}
+{{- $hasLegacy := or (gt (int .Values.hub.github.app.id) 0) (gt (int .Values.hub.github.app.installId) 0) -}}
+{{- if and $hasApps $hasLegacy -}}
+{{- fail "hub.github.apps is mutually exclusive with hub.github.app.id / hub.github.app.installId. Use one mode or the other." -}}
+{{- end -}}
+{{- if $hasApps -}}
+{{- include "lunar.githubAppsCheck" . -}}
+{{- else -}}
 {{- if not (gt (int .Values.hub.github.app.id) 0) -}}
-{{- fail "hub.github.app.id is required (numeric, non-zero). Run scripts/create-github-app.sh in the lunar repo to create one if you don't have it yet." -}}
+{{- fail "hub.github.app.id is required (numeric, non-zero), or use hub.github.apps for multi-App routing. Run scripts/create-github-app.sh in the lunar repo to create one if you don't have it yet." -}}
 {{- end -}}
 {{- if not (gt (int .Values.hub.github.app.installId) 0) -}}
 {{- fail "hub.github.app.installId is required (numeric, non-zero). It's the installation ID for the App on your org or repo." -}}
@@ -78,6 +86,52 @@ Fail fast when GitHub App auth is misconfigured.
 {{- if not .Values.hub.github.app.privateKey.secretName -}}
 {{- fail "hub.github.app.privateKey.secretName is required. Create a Kubernetes secret holding the App's private-key PEM." -}}
 {{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate the multi-App config (hub.github.apps + hub.github.appsSecret).
+Called from lunar.githubAuthCheck when apps is non-empty.
+*/}}
+{{- define "lunar.githubAppsCheck" -}}
+{{- if not .Values.hub.github.appsSecret.secretName -}}
+{{- fail "hub.github.appsSecret.secretName is required when hub.github.apps is set. Create a Kubernetes secret with one PEM key per entry, named '<lowercase-owner>.pem'." -}}
+{{- end -}}
+{{- $seen := dict -}}
+{{- range $i, $app := .Values.hub.github.apps -}}
+{{- if not $app.owner -}}
+{{- fail (printf "hub.github.apps[%d].owner is required" $i) -}}
+{{- end -}}
+{{- if not (gt (int $app.appId) 0) -}}
+{{- fail (printf "hub.github.apps[%d] (%s): appId is required (numeric, non-zero)" $i $app.owner) -}}
+{{- end -}}
+{{- if not (gt (int $app.installId) 0) -}}
+{{- fail (printf "hub.github.apps[%d] (%s): installId is required (numeric, non-zero)" $i $app.owner) -}}
+{{- end -}}
+{{- $key := lower $app.owner -}}
+{{- if hasKey $seen $key -}}
+{{- fail (printf "hub.github.apps: duplicate owner %q (case-insensitive)" $app.owner) -}}
+{{- end -}}
+{{- $_ := set $seen $key true -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render the HUB_GITHUB_APPS JSON env value from hub.github.apps. Each
+entry's private_key_path is derived from <lowercase-owner>.pem under
+the Secret mountPath /secrets/github-apps. Used by hub-deployment.yaml.
+*/}}
+{{- define "lunar.githubAppsJSON" -}}
+{{- $entries := list -}}
+{{- range .Values.hub.github.apps -}}
+{{- $entries = append $entries (dict
+    "owner" .owner
+    "app_id" (.appId | int64)
+    "private_key_path" (printf "/secrets/github-apps/%s.pem" (lower .owner))
+    "install_id" (.installId | int64)
+) -}}
+{{- end -}}
+{{- $entries | toJson -}}
 {{- end }}
 
 {{/*

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -86,6 +86,10 @@ spec:
               value: {{ .github.syncWindow | quote }}
             - name: HUB_GITHUB_BASE_URL
               value: {{ .github.baseUrl | quote }}
+            {{- if gt (len .github.apps) 0 }}
+            - name: HUB_GITHUB_APPS
+              value: {{ include "lunar.githubAppsJSON" $ | quote }}
+            {{- else }}
             - name: HUB_GITHUB_APP_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:
@@ -95,6 +99,7 @@ spec:
               value: {{ .github.app.id | quote }}
             - name: HUB_GITHUB_APP_INSTALL_ID
               value: {{ .github.app.installId | quote }}
+            {{- end }}
             - name: HUB_POLICY_QUEUE_POLL_INTERVAL
               value: {{ .policyQueue.pollInterval | quote }}
             - name: HUB_POLICY_QUEUE_NUM_WORKERS
@@ -224,6 +229,11 @@ spec:
               mountPath: {{ .Values.hub.licence.filePath | quote }}
               subPath: {{ base .Values.hub.licence.filePath | quote }}
               readOnly: true
+            {{- if gt (len .Values.hub.github.apps) 0 }}
+            - name: github-apps
+              mountPath: /secrets/github-apps
+              readOnly: true
+            {{- end }}
             {{- with .Values.hub.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -240,6 +250,11 @@ spec:
             items:
               - key: {{ .Values.hub.licence.secretKey }}
                 path: {{ base .Values.hub.licence.filePath | quote }}
+        {{- if gt (len .Values.hub.github.apps) 0 }}
+        - name: github-apps
+          secret:
+            secretName: {{ .Values.hub.github.appsSecret.secretName }}
+        {{- end }}
         {{- with .Values.hub.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -90,6 +90,8 @@ spec:
             - name: HUB_GITHUB_APPS
               value: {{ include "lunar.githubAppsJSON" $ | quote }}
             {{- else }}
+            - name: HUB_GITHUB_APP_OWNER
+              value: {{ .github.app.owner | quote }}
             - name: HUB_GITHUB_APP_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -90,7 +90,7 @@ hub:
       # owner: the GitHub org (or user) the App is installed on. Required
       # in single-App mode — the Hub uses this to route every webhook
       # through the configured installation. Operators upgrading from
-      # chart < 2.1.0 must set this; previously the field was implicit.
+      # chart < 2.2.0 must set this; previously the field was implicit.
       owner: ""
       privateKey:
         secretName: "lunar-github-app"

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -87,6 +87,11 @@ hub:
     # Hub fronts one GitHub App installed in one org. Mutually exclusive
     # with hub.github.apps below.
     app:
+      # owner: the GitHub org (or user) the App is installed on. Required
+      # in single-App mode — the Hub uses this to route every webhook
+      # through the configured installation. Operators upgrading from
+      # chart < 3.0.0 must set this; previously the field was implicit.
+      owner: ""
       privateKey:
         secretName: "lunar-github-app"
         secretKey: "private-key"

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -90,7 +90,7 @@ hub:
       # owner: the GitHub org (or user) the App is installed on. Required
       # in single-App mode — the Hub uses this to route every webhook
       # through the configured installation. Operators upgrading from
-      # chart < 3.0.0 must set this; previously the field was implicit.
+      # chart < 2.1.0 must set this; previously the field was implicit.
       owner: ""
       privateKey:
         secretName: "lunar-github-app"

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -83,12 +83,44 @@ hub:
     connectionOptions: "sslmode=require"
   github:
     baseUrl: ""
+    # Single-App config. Use this for single-tenant deployments where the
+    # Hub fronts one GitHub App installed in one org. Mutually exclusive
+    # with hub.github.apps below.
     app:
       privateKey:
         secretName: "lunar-github-app"
         secretKey: "private-key"
       id: 0
       installId: 0
+    # Multi-App config. Use this when the Hub serves multiple orgs that
+    # each install their own Lunar App. Each entry pins one repository
+    # owner to a distinct (appId, installId) tuple, and the PEM files for
+    # all entries live in a single Kubernetes Secret referenced by
+    # appsSecret below. Mutually exclusive with the single-App fields
+    # above.
+    #
+    # Example:
+    #   apps:
+    #     - owner: earthly
+    #       appId: 123
+    #       installId: 100
+    #     - owner: acme
+    #       appId: 456
+    #       installId: 200
+    #
+    # The chart looks up each entry's PEM at
+    # <appsSecret.secretName>/<lowercase-owner>.pem, mounted at
+    # /secrets/github-apps inside the hub container.
+    apps: []
+    # Operator-created Secret holding one PEM key per entry above. Each
+    # entry expects a data key named "<lowercase owner>.pem". The chart
+    # does not generate this Secret — create it with kubectl, e.g.:
+    #
+    #   kubectl create secret generic lunar-github-apps \
+    #     --from-file=earthly.pem=./earthly.pem \
+    #     --from-file=acme.pem=./acme.pem
+    appsSecret:
+      secretName: "lunar-github-apps"
     # Webhook secret. Leave secretName empty to have the chart generate one
     # (recommended for fresh installs). The chart-managed secret persists
     # across upgrade and uninstall (helm.sh/resource-policy: keep). Retrieve:


### PR DESCRIPTION
## Summary

Adds multi-App GitHub auth support to the lunar chart, matching the new `HUB_GITHUB_APPS` env in the Hub (lunar#1593). One Hub can now route per-owner to distinct GitHub Apps with separate IDs, installs, and private keys.

`hub.github.apps` lists `{owner, appId, installId}` entries; `hub.github.appsSecret.secretName` points to an operator-managed Secret holding one PEM per entry, keyed `<lowercase-owner>.pem`. Render-time validation (`helm.sh/fail`) enforces mutual exclusivity with the legacy `hub.github.app.*` fields, required fields per entry, and unique case-insensitive owners.

In multi-App mode the chart mounts the Secret at `/secrets/github-apps` and renders `HUB_GITHUB_APPS` JSON with `private_key_path` references. Legacy single-App rendering is unchanged.

## Example

```yaml
hub:
  github:
    apps:
      - owner: earthly
        appId: 123
        installId: 100
      - owner: acme
        appId: 456
        installId: 200
    appsSecret:
      secretName: lunar-github-apps
```

```bash
kubectl create secret generic lunar-github-apps \
  --from-file=earthly.pem=./earthly.pem \
  --from-file=acme.pem=./acme.pem
```
