### PR TITLE
chart 2.0.0: dual-ingress support (api vs webhooks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ The central gRPC/HTTP server. Stores metadata, evaluates policies, and serves th
 | Key | Description | Default |
 |-----|-------------|---------|
 | `hub.webhookURL` | External URL where GitHub posts webhooks. Chart registers `<webhookURL>/webhooks/github` with the GitHub App at boot. Defaults to `https://<hub.ingress.webhooks.host>` when chart-managed ingress is enabled. Set explicitly only when ingress is disabled (BYO) or you need a non-default scheme/port/path. | `""` (derived) |
-| `hub.grafanaURLBase` | Base URL Hub uses for `[More Details]` links in PR comments. Resolution chain when empty: (1) `https://<grafana.ingress.hosts[0].host>` if chart-managed Grafana ingress; (2) `https://<hub.ingress.api.host>` if chart-managed Hub ingress (internal trust boundary, deliberately not the public webhooks host); (3) `hub.webhookURL` as BYO fallback. Override when Grafana lives on a hostname none of these capture. | `""` (derived) |
+| `hub.grafanaURLBase` | Base URL where Grafana is reachable. Drives both `HUB_GRAFANA_URL_BASE` (`[More Details]` links in PR comments) and `GF_SERVER_ROOT_URL` (Grafana's self-knowledge — used for OIDC `redirect_uri` generation, absolute link rendering, etc). Resolution chain when empty: (1) `https://<grafana.ingress.hosts[0].host>` if chart-managed Grafana ingress; (2) `https://<hub.ingress.api.host>` if chart-managed Hub ingress (internal trust boundary, deliberately not the public webhooks host); (3) `hub.webhookURL` as BYO fallback. Override when Grafana lives on a hostname none of these capture. | `""` (derived) |
 
 **Licence**
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,16 @@ hub:
       installId: 78901234
 ```
 
-For GitHub webhook registration to work, the hub also needs an externally-reachable URL. The simplest path is to let the chart manage your ingress and set `hub.ingress.webhooks.host` — see [Ingress](#ingress) below. When `hub.ingress.enabled: true`, the chart derives `https://<webhooks.host>` automatically. BYO-ingress installs (`hub.ingress.enabled: false`) must set `hub.webhookURL` explicitly — the chart will not guess a URL it doesn't route to.
+Plus two URL prerequisites the chart needs to wire correctly:
+
+1. **Hub webhook URL** — for GitHub webhook registration to work, the hub needs an externally-reachable URL. The simplest path is to let the chart manage your ingress and set `hub.ingress.webhooks.host` — see [Ingress](#ingress) below. When `hub.ingress.enabled: true`, the chart derives `https://<webhooks.host>` automatically. BYO-ingress installs (`hub.ingress.enabled: false`) must set `hub.webhookURL` explicitly — the chart will not guess a URL it doesn't route to.
+
+2. **Grafana URL** (when `grafana.enabled: true`, which is the default) — Grafana needs to know its own external URL for OIDC `redirect_uri` and absolute link rendering. Pick one:
+   - `grafana.ingress.enabled: true` with `grafana.ingress.hosts[0].host` set — chart derives the URL automatically.
+   - `grafana.externalURL: "https://grafana.example.com"` — explicit override, for BYO ingress / Caddy / shared LB with path routing.
+   - `grafana.enabled: false` — skip Grafana entirely.
+
+   The chart fails fast at install time if none of these are set (it deliberately won't guess at a URL it doesn't route to — wrong host means broken OIDC, silently).
 
 ### GitHub authentication
 
@@ -534,7 +543,7 @@ The Hub uses a PVC for state, cached repos, and script code.
 | `hub.ingress.api.host` | Hostname for the API ingress (gRPC + `/logs`). Required when enabled. | `""` |
 | `hub.ingress.api.className` | Override `ingress.className` for the API ingress. | `""` |
 | `hub.ingress.api.tls` | Override `ingress.tls` for the API ingress. | `[]` |
-| `hub.ingress.api.grpcAnnotations` | Annotations applied only to the api-grpc Ingress, layered on top of `ingress.annotations` (typically NGINX `backend-protocol: GRPC`). | NGINX `backend-protocol: GRPC` |
+| `hub.ingress.api.grpcAnnotations` | Annotations applied only to the api-grpc Ingress, layered on top of `ingress.annotations`. NGINX users need `backend-protocol: GRPC` here (other controllers have their own equivalent — see [Ingress](#ingress) for examples). Controller-neutral default — set explicitly for your ingress class. | `{}` |
 | `hub.ingress.api.httpAnnotations` | Annotations applied only to the api-http (`/logs`) Ingress, layered on top of `ingress.annotations`. | `{}` |
 | `hub.ingress.webhooks.host` | Hostname for the webhooks ingress (GitHub `/webhooks`). Required when `ingress.enabled: true`. Source of the derived `hub.webhookURL` (only in that case — when ingress is disabled the chart does not derive from this field). | `""` |
 | `hub.ingress.webhooks.className` | Override `ingress.className` for the webhooks ingress. | `""` |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ Minimum `values.yaml` that has to be provided — everything else has a sensible
 
 ```yaml
 hub:
-  publicBaseURL: "https://lunar.example.com"
   licence:
     secretName: "lunar-hub-licence"
     secretKey: "hub-licence.jwt"
@@ -102,7 +101,7 @@ hub:
       installId: 78901234
 ```
 
-`hub.publicBaseURL` should resolve to the Hub from the public internet — it's used for automatic GitHub webhook registration (see [Webhooks](#webhooks) below).
+For GitHub webhook registration to work, the hub also needs an externally-reachable URL. The simplest path is to let the chart manage your ingress and set `hub.ingress.webhooks.host` — see [Ingress](#ingress) below. The hub uses `https://<webhooks.host>` automatically. If you front the hub yourself, set `hub.webhookURL` explicitly.
 
 ### GitHub authentication
 
@@ -167,13 +166,19 @@ kubectl -n lunar create secret generic my-grafana-admin \
 
 ## Ingress
 
-The hub serves gRPC (port 8000, used by CLI / CI agents / operator) and HTTP (port 8001, GitHub webhooks + log redirects) on separate ports. Most ingress controllers — NGINX especially — apply backend-protocol annotations per-Ingress, not per-path, so when ingress is enabled the chart renders **two Ingress resources** sharing the same host and TLS config (same shape as Argo CD's chart). Disable entirely if you front the hub with a LoadBalancer Service, a service mesh, or another ingress mechanism.
+The hub has two trust boundaries:
+
+1. **Trusted API clients** — lunar CLI, CI agents, operator. Talk to hub over gRPC (port 8000) and HTTP (`/logs` on port 8001). Both use the same Hub auth token.
+2. **GitHub webhooks** — public internet. POST to `/webhooks` on port 8001 only.
+
+The chart renders separate ingresses for each, configured under two logical blocks: `hub.ingress.api` and `hub.ingress.webhooks`. You can put the API ingress on a private hostname (Tailscale, internal-DNS, VPN) and only expose webhooks to the public internet — or use the same hostname for both. Disable entirely (`hub.ingress.enabled: false`) if you front the hub with a LoadBalancer Service, a service mesh, or your own Ingress YAML.
+
+**Single-host install** (same hostname serves both — fine for most setups):
 
 ```yaml
 hub:
   ingress:
     enabled: true
-    host: lunar.example.com
     className: nginx
     tls:
       - secretName: lunar-tls
@@ -181,12 +186,120 @@ hub:
           - lunar.example.com
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
-    grpcAnnotations:
-      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-    httpAnnotations: {}
+    api:
+      host: lunar.example.com
+    webhooks:
+      host: lunar.example.com
 ```
 
-The gRPC ingress routes `/` to the hub's gRPC port. The HTTP ingress routes `/webhooks` (GitHub webhook receiver) and `/logs` (signed-URL log redirects) to the hub's HTTP port.
+**Split-host install** (API stays internal, webhooks ingress is the only public surface):
+
+```yaml
+hub:
+  ingress:
+    enabled: true
+    className: nginx
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt
+    api:
+      host: api.lunar.example.com
+      tls:
+        - secretName: lunar-api-tls
+          hosts:
+            - api.lunar.example.com
+      annotations:
+        # Restrict to an internal network range, for example.
+        nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/8"
+    webhooks:
+      host: webhooks.lunar.example.com
+      tls:
+        - secretName: lunar-webhooks-tls
+          hosts:
+            - webhooks.lunar.example.com
+```
+
+### Why `webhookURL` must match `webhooks.host`
+
+When the hub boots, it reads `HUB_PUBLIC_BASE_URL` (the chart sets this from `hub.webhookURL`, which defaults to `https://<hub.ingress.webhooks.host>`) and registers `<webhookURL>/webhooks/github` with the GitHub App. GitHub then POSTs every webhook event to that URL, which must resolve to the webhooks ingress.
+
+```mermaid
+sequenceDiagram
+    participant Hub as Hub<br/>(reads webhookURL)
+    participant GH as GitHub App
+    participant DNS
+    participant Ingress as Webhooks Ingress<br/>(listens on webhooks.host)
+    participant HubPod as Hub Pod<br/>:8001
+
+    Hub->>GH: "Register webhook at <webhookURL>/webhooks/github"
+    Note over Hub,GH: One-time, at hub boot
+
+    Note over GH: Later: a PR event happens
+    GH->>DNS: Resolve <webhookURL host>
+    DNS-->>GH: Cluster LB IP
+    GH->>Ingress: POST /webhooks/github
+    Ingress->>HubPod: Forward
+    HubPod-->>Ingress: 200 OK
+    Ingress-->>GH: 200 OK
+```
+
+Three things must agree, or webhooks land in the void:
+
+1. The hostname inside `hub.webhookURL` (derived from `webhooks.host` by default).
+2. The DNS record for that hostname must resolve to your cluster's ingress.
+3. An Ingress with a rule for that hostname and `/webhooks` path — which the chart creates for you when `hub.ingress.enabled: true`.
+
+The chart enforces #1 internally: if you explicitly set `hub.webhookURL`, its host portion must equal `hub.ingress.webhooks.host`. Install fails fast if they disagree.
+
+### What gets rendered
+
+Three `Ingress` resources, all in the release namespace:
+
+| Resource | Host | Path | Backend port |
+|----------|------|------|--------------|
+| `<release>-hub-api-grpc` | `api.host` | `/` | hub gRPC (8000) |
+| `<release>-hub-api-http` | `api.host` | `/logs` | hub HTTP (8001) |
+| `<release>-hub-webhooks` | `webhooks.host` | `/webhooks` | hub HTTP (8001) |
+
+The `api-grpc` and `api-http` split exists because most ingress controllers apply `backend-protocol` annotations per-Ingress.
+
+## Migrating from chart 1.x
+
+The ingress shape changed in chart 2.0.0. `hub.publicBaseURL` was renamed to `hub.webhookURL` (and now defaults to `https://<webhooks.host>`). `hub.ingress.host` / `grpcAnnotations` / `httpAnnotations` moved under `hub.ingress.api.*` and `hub.ingress.webhooks.*`. The chart fails fast at install time when it sees the old shape.
+
+```yaml
+# Before (chart 1.x)
+hub:
+  publicBaseURL: "https://lunar.example.com"
+  ingress:
+    enabled: true
+    host: lunar.example.com
+    grpcAnnotations:
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+
+# After (chart 2.0.0) — single-host
+hub:
+  # webhookURL is derived as "https://lunar.example.com" automatically.
+  ingress:
+    enabled: true
+    api:
+      host: lunar.example.com
+      grpcAnnotations:
+        nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    webhooks:
+      host: lunar.example.com
+
+# After (chart 2.0.0) — split-host (NEW capability)
+hub:
+  # webhookURL derived as "https://webhooks.lunar.example.com".
+  ingress:
+    enabled: true
+    api:
+      host: api.lunar.example.com
+      grpcAnnotations:
+        nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    webhooks:
+      host: webhooks.lunar.example.com
+```
 
 ## Post-install
 
@@ -200,10 +313,10 @@ lunar hub pull github://your-org/your-config-repo@main
 
 ### Webhooks
 
-The Hub automatically registers per-repo GitHub webhooks at `<hub.publicBaseURL>/webhooks/github` when manifests are pulled. No manual webhook configuration is required as long as:
+The Hub automatically registers per-repo GitHub webhooks at `<hub.webhookURL>/webhooks/github` when manifests are pulled. No manual webhook configuration is required as long as:
 
-- `hub.publicBaseURL` is set and reachable from GitHub
-- The GitHub App has the `repository_hooks: write` permission (the manifest script grants this by default)
+- `hub.webhookURL` resolves to your webhooks ingress and is reachable from GitHub. When chart-managed ingress is enabled, this is derived from `hub.ingress.webhooks.host` automatically.
+- The GitHub App has the `repository_hooks: write` permission (the manifest script grants this by default).
 
 ## Upgrading
 
@@ -267,7 +380,8 @@ The central gRPC/HTTP server. Stores metadata, evaluates policies, and serves th
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `hub.publicBaseURL` | Externally-reachable base URL for the Hub. Required for automatic GitHub webhook registration | `""` |
+| `hub.webhookURL` | External URL where GitHub posts webhooks. Chart registers `<webhookURL>/webhooks/github` with the GitHub App at boot. Defaults to `https://<hub.ingress.webhooks.host>` when chart-managed ingress is enabled. Set explicitly only when ingress is disabled (BYO) or you need a non-default scheme/port/path. | `""` (derived) |
+| `hub.grafanaURLBase` | Base URL Hub uses for `[More Details]` links in PR comments. Defaults to `webhookURL` — correct for single-host installs where Grafana is path-routed under the same host. Override when Grafana is served from a separate hostname. | `""` (derived) |
 
 **Licence**
 
@@ -376,13 +490,20 @@ The Hub uses a PVC for state, cached repos, and script code.
 | `hub.service.type` | Service type | `ClusterIP` |
 | `hub.service.ports.server` | gRPC port | `8000` |
 | `hub.service.ports.http` | HTTP port | `8001` |
-| `hub.ingress.enabled` | Render the gRPC + HTTP ingresses for the hub | `false` |
-| `hub.ingress.host` | Hostname shared by both ingresses (required when enabled) | `""` |
-| `hub.ingress.className` | Ingress class | `""` |
-| `hub.ingress.tls` | Ingress TLS config (shared) | `[]` |
-| `hub.ingress.annotations` | Annotations applied to both ingresses | `{}` |
-| `hub.ingress.grpcAnnotations` | Annotations applied only to the gRPC ingress | `{}` |
-| `hub.ingress.httpAnnotations` | Annotations applied only to the HTTP ingress | `{}` |
+| `hub.ingress.enabled` | Render the hub ingresses (three resources: api-grpc, api-http, webhooks) | `false` |
+| `hub.ingress.className` | Shared default ingress class. Overridden per-block when set. | `""` |
+| `hub.ingress.tls` | Shared default TLS config. Overridden per-block when set. | `[]` |
+| `hub.ingress.annotations` | Shared default annotations applied to all three ingresses. | `{}` |
+| `hub.ingress.api.host` | Hostname for the API ingress (gRPC + `/logs`). Required when enabled. | `""` |
+| `hub.ingress.api.className` | Override `ingress.className` for the API ingress. | `""` |
+| `hub.ingress.api.tls` | Override `ingress.tls` for the API ingress. | `[]` |
+| `hub.ingress.api.annotations` | Annotations layered on top of `ingress.annotations` for both API sub-ingresses. | `{}` |
+| `hub.ingress.api.grpcAnnotations` | Annotations applied only to the api-grpc Ingress (typically NGINX `backend-protocol: GRPC`). | NGINX `backend-protocol: GRPC` |
+| `hub.ingress.api.httpAnnotations` | Annotations applied only to the api-http (`/logs`) Ingress. | `{}` |
+| `hub.ingress.webhooks.host` | Hostname for the webhooks ingress (GitHub `/webhooks`). Required when enabled. Also the source of truth for derived `hub.webhookURL`. | `""` |
+| `hub.ingress.webhooks.className` | Override `ingress.className` for the webhooks ingress. | `""` |
+| `hub.ingress.webhooks.tls` | Override `ingress.tls` for the webhooks ingress. | `[]` |
+| `hub.ingress.webhooks.annotations` | Annotations layered on top of `ingress.annotations` for the webhooks ingress. | `{}` |
 
 **Probes**
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ hub:
       installId: 78901234
 ```
 
-For GitHub webhook registration to work, the hub also needs an externally-reachable URL. The simplest path is to let the chart manage your ingress and set `hub.ingress.webhooks.host` — see [Ingress](#ingress) below. The hub uses `https://<webhooks.host>` automatically. If you front the hub yourself, set `hub.webhookURL` explicitly.
+For GitHub webhook registration to work, the hub also needs an externally-reachable URL. The simplest path is to let the chart manage your ingress and set `hub.ingress.webhooks.host` — see [Ingress](#ingress) below. When `hub.ingress.enabled: true`, the chart derives `https://<webhooks.host>` automatically. BYO-ingress installs (`hub.ingress.enabled: false`) must set `hub.webhookURL` explicitly — the chart will not guess a URL it doesn't route to.
 
 ### GitHub authentication
 
@@ -207,8 +207,13 @@ hub:
         - secretName: lunar-api-tls
           hosts:
             - api.lunar.example.com
-      annotations:
-        # Restrict to an internal network range, for example.
+      # Per-sub-Ingress annotations. Repeat the whitelist on both so it
+      # applies to api-grpc AND api-http; the chart intentionally does not
+      # apply it to webhooks (different trust boundary).
+      grpcAnnotations:
+        nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+        nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/8"
+      httpAnnotations:
         nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/8"
     webhooks:
       host: webhooks.lunar.example.com
@@ -218,9 +223,9 @@ hub:
             - webhooks.lunar.example.com
 ```
 
-### Why `webhookURL` must match `webhooks.host`
+### How webhooks reach the hub
 
-When the hub boots, it reads `HUB_PUBLIC_BASE_URL` (the chart sets this from `hub.webhookURL`, which defaults to `https://<hub.ingress.webhooks.host>`) and registers `<webhookURL>/webhooks/github` with the GitHub App. GitHub then POSTs every webhook event to that URL, which must resolve to the webhooks ingress.
+When the hub boots, it reads `hub.webhookURL` (derived as `https://<hub.ingress.webhooks.host>` when `hub.ingress.enabled: true`; must be set explicitly otherwise) and registers `<webhookURL>/webhooks/github` with the GitHub App. GitHub then POSTs every webhook event to that URL, which must resolve to the webhooks ingress.
 
 ```mermaid
 sequenceDiagram
@@ -244,11 +249,11 @@ sequenceDiagram
 
 Three things must agree, or webhooks land in the void:
 
-1. The hostname inside `hub.webhookURL` (derived from `webhooks.host` by default).
+1. The hostname inside `hub.webhookURL` (derived from `webhooks.host` when `hub.ingress.enabled: true`; set explicitly otherwise).
 2. The DNS record for that hostname must resolve to your cluster's ingress.
-3. An Ingress with a rule for that hostname and `/webhooks` path — which the chart creates for you when `hub.ingress.enabled: true`.
+3. An Ingress with a rule for that hostname and `/webhooks` path — which the chart creates for you when `hub.ingress.enabled: true`; BYO installs are responsible for routing themselves.
 
-The chart enforces #1 internally: if you explicitly set `hub.webhookURL`, its host portion must equal `hub.ingress.webhooks.host`. Install fails fast if they disagree.
+The chart enforces #1 internally: if you set `hub.webhookURL` explicitly alongside chart-managed ingress, its host portion must equal `hub.ingress.webhooks.host`. Install fails fast if they disagree.
 
 ### What gets rendered
 
@@ -264,7 +269,13 @@ The `api-grpc` and `api-http` split exists because most ingress controllers appl
 
 ## Migrating from chart 1.x
 
-The ingress shape changed in chart 2.0.0. `hub.publicBaseURL` was renamed to `hub.webhookURL` (and now defaults to `https://<webhooks.host>`). `hub.ingress.host` / `grpcAnnotations` / `httpAnnotations` moved under `hub.ingress.api.*` and `hub.ingress.webhooks.*`. The chart fails fast at install time when it sees the old shape.
+The ingress shape changed in chart 2.0.0:
+
+- `hub.publicBaseURL` was renamed to `hub.webhookURL`, and is now optional when `hub.ingress.enabled: true` — defaults to `https://<webhooks.host>` in that case. BYO-ingress installs must set it explicitly (the chart will not derive a URL it doesn't route to). Also set explicitly for non-default scheme/port or a path prefix.
+- `hub.ingress.host` moved to `hub.ingress.api.host` **and** `hub.ingress.webhooks.host` (set both to the same value for a single-host install).
+- `hub.ingress.grpcAnnotations` / `httpAnnotations` moved under `hub.ingress.api.*`.
+
+The chart fails fast at install time when it sees the old shape.
 
 ```yaml
 # Before (chart 1.x)
@@ -278,7 +289,7 @@ hub:
 
 # After (chart 2.0.0) — single-host
 hub:
-  # webhookURL is derived as "https://lunar.example.com" automatically.
+  # webhookURL derived as "https://lunar.example.com" automatically.
   ingress:
     enabled: true
     api:
@@ -299,6 +310,21 @@ hub:
         nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     webhooks:
       host: webhooks.lunar.example.com
+
+# After (chart 2.0.0) — BYO ingress (LoadBalancer / mesh / your own YAML).
+# The chart wires HUB_PUBLIC_BASE_URL, HUB_GRAFANA_URL_BASE, and Grafana's
+# GF_SERVER_ROOT_URL from the values below — set whichever apply. You own
+# routing GitHub's POSTs to the hub-http Service (named `<release>-hub:8001`)
+# and routing browser traffic to the grafana Service. The chart only emits
+# these env vars when the corresponding value is set; unset means the
+# component falls back to its own default (or warns at boot).
+hub:
+  webhookURL: "https://lunar.example.com"
+  # Required when Grafana is reachable via external routing — otherwise
+  # GF_SERVER_ROOT_URL is empty and OIDC redirect_uris break.
+  grafanaURLBase: "https://grafana.example.com"
+  ingress:
+    enabled: false
 ```
 
 ## Post-install
@@ -380,8 +406,8 @@ The central gRPC/HTTP server. Stores metadata, evaluates policies, and serves th
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `hub.webhookURL` | External URL where GitHub posts webhooks. Chart registers `<webhookURL>/webhooks/github` with the GitHub App at boot. Defaults to `https://<hub.ingress.webhooks.host>` when chart-managed ingress is enabled. Set explicitly only when ingress is disabled (BYO) or you need a non-default scheme/port/path. | `""` (derived) |
-| `hub.grafanaURLBase` | Base URL where Grafana is reachable. Drives both `HUB_GRAFANA_URL_BASE` (`[More Details]` links in PR comments) and `GF_SERVER_ROOT_URL` (Grafana's self-knowledge — used for OIDC `redirect_uri` generation, absolute link rendering, etc). Resolution chain when empty: (1) `https://<grafana.ingress.hosts[0].host>` if chart-managed Grafana ingress; (2) `https://<hub.ingress.api.host>` if chart-managed Hub ingress (internal trust boundary, deliberately not the public webhooks host); (3) `hub.webhookURL` as BYO fallback. Override when Grafana lives on a hostname none of these capture. | `""` (derived) |
+| `hub.webhookURL` | External URL where GitHub posts webhooks. Chart registers `<webhookURL>/webhooks/github` with the GitHub App at boot. Defaults to `https://<hub.ingress.webhooks.host>` **only when `hub.ingress.enabled: true`** — the chart only derives a URL when it actually routes the traffic. Set explicitly when ingress is disabled (BYO) or you need a non-default scheme/port/path. When set explicitly alongside chart-managed ingress, the host portion must equal `hub.ingress.webhooks.host` — install fails fast otherwise. | `""` (derived) |
+| `hub.grafanaURLBase` | Base URL where Grafana is reachable. Drives both `HUB_GRAFANA_URL_BASE` (`[More Details]` links in PR comments) and `GF_SERVER_ROOT_URL` (Grafana's self-knowledge — used for OIDC `redirect_uri` generation, absolute link rendering, etc). Defaults to `https://<grafana.ingress.hosts[0].host>` when chart-managed Grafana ingress is enabled. Empty otherwise — the chart only derives a URL when it actually controls the routing (no fallback to `webhookURL` or `api.host` — wrong trust boundary). Installs with externally-managed Grafana routing **must** set this explicitly, especially when Grafana fronts OIDC. | `""` (derived) |
 
 **Licence**
 
@@ -497,10 +523,9 @@ The Hub uses a PVC for state, cached repos, and script code.
 | `hub.ingress.api.host` | Hostname for the API ingress (gRPC + `/logs`). Required when enabled. | `""` |
 | `hub.ingress.api.className` | Override `ingress.className` for the API ingress. | `""` |
 | `hub.ingress.api.tls` | Override `ingress.tls` for the API ingress. | `[]` |
-| `hub.ingress.api.annotations` | Annotations layered on top of `ingress.annotations` for both API sub-ingresses. | `{}` |
-| `hub.ingress.api.grpcAnnotations` | Annotations applied only to the api-grpc Ingress (typically NGINX `backend-protocol: GRPC`). | NGINX `backend-protocol: GRPC` |
-| `hub.ingress.api.httpAnnotations` | Annotations applied only to the api-http (`/logs`) Ingress. | `{}` |
-| `hub.ingress.webhooks.host` | Hostname for the webhooks ingress (GitHub `/webhooks`). Required when enabled. Also the source of truth for derived `hub.webhookURL`. | `""` |
+| `hub.ingress.api.grpcAnnotations` | Annotations applied only to the api-grpc Ingress, layered on top of `ingress.annotations` (typically NGINX `backend-protocol: GRPC`). | NGINX `backend-protocol: GRPC` |
+| `hub.ingress.api.httpAnnotations` | Annotations applied only to the api-http (`/logs`) Ingress, layered on top of `ingress.annotations`. | `{}` |
+| `hub.ingress.webhooks.host` | Hostname for the webhooks ingress (GitHub `/webhooks`). Required when `ingress.enabled: true`. Source of the derived `hub.webhookURL` (only in that case — when ingress is disabled the chart does not derive from this field). | `""` |
 | `hub.ingress.webhooks.className` | Override `ingress.className` for the webhooks ingress. | `""` |
 | `hub.ingress.webhooks.tls` | Override `ingress.tls` for the webhooks ingress. | `[]` |
 | `hub.ingress.webhooks.annotations` | Annotations layered on top of `ingress.annotations` for the webhooks ingress. | `{}` |

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ The central gRPC/HTTP server. Stores metadata, evaluates policies, and serves th
 | Key | Description | Default |
 |-----|-------------|---------|
 | `hub.webhookURL` | External URL where GitHub posts webhooks. Chart registers `<webhookURL>/webhooks/github` with the GitHub App at boot. Defaults to `https://<hub.ingress.webhooks.host>` when chart-managed ingress is enabled. Set explicitly only when ingress is disabled (BYO) or you need a non-default scheme/port/path. | `""` (derived) |
-| `hub.grafanaURLBase` | Base URL Hub uses for `[More Details]` links in PR comments. Defaults to `webhookURL` — correct for single-host installs where Grafana is path-routed under the same host. Override when Grafana is served from a separate hostname. | `""` (derived) |
+| `hub.grafanaURLBase` | Base URL Hub uses for `[More Details]` links in PR comments. Resolution chain when empty: (1) `https://<grafana.ingress.hosts[0].host>` if chart-managed Grafana ingress; (2) `https://<hub.ingress.api.host>` if chart-managed Hub ingress (internal trust boundary, deliberately not the public webhooks host); (3) `hub.webhookURL` as BYO fallback. Override when Grafana lives on a hostname none of these capture. | `""` (derived) |
 
 **Licence**
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ hub:
       cert-manager.io/cluster-issuer: letsencrypt
     api:
       host: lunar.example.com
+      # NGINX needs backend-protocol: GRPC on the gRPC Ingress. Other
+      # controllers use their own equivalent (ALB: backend-protocol-version:
+      # GRPC; Traefik: h2c per-service; etc).
+      grpcAnnotations:
+        nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     webhooks:
       host: lunar.example.com
 ```
@@ -274,6 +279,9 @@ The ingress shape changed in chart 2.0.0:
 - `hub.publicBaseURL` was renamed to `hub.webhookURL`, and is now optional when `hub.ingress.enabled: true` — defaults to `https://<webhooks.host>` in that case. BYO-ingress installs must set it explicitly (the chart will not derive a URL it doesn't route to). Also set explicitly for non-default scheme/port or a path prefix.
 - `hub.ingress.host` moved to `hub.ingress.api.host` **and** `hub.ingress.webhooks.host` (set both to the same value for a single-host install).
 - `hub.ingress.grpcAnnotations` / `httpAnnotations` moved under `hub.ingress.api.*`.
+- `hub.ingress.api.grpcAnnotations` no longer defaults to NGINX's `backend-protocol: "GRPC"`. NGINX users must set it explicitly (see [Ingress](#ingress) examples); other controllers set their equivalent.
+- `hub.grafanaURLBase` was renamed to `grafana.externalURL`. It's a Grafana property — Hub consumes it as `HUB_GRAFANA_URL_BASE`, Grafana consumes it as `GF_SERVER_ROOT_URL`. Lives under `grafana.*` now, where it belongs.
+- **Grafana URL derivation changed.** In 1.x, `HUB_GRAFANA_URL_BASE` and Grafana's own `GF_SERVER_ROOT_URL` defaulted to `publicBaseURL`. 2.0.0 only derives a Grafana URL when the chart actually controls Grafana's routing (chart-managed `grafana.ingress` or explicit `grafana.externalURL`). **If you used a single hostname with `grafana.ingress.enabled: false` and external path-routing (Caddy / nginx-ingress with split paths / similar), set `grafana.externalURL` to that same URL explicitly** — otherwise Grafana's OIDC `redirect_uri` and absolute links break after upgrade. The chart fails fast at install time when `grafana.enabled: true` and no Grafana URL can be determined.
 
 The chart fails fast at install time when it sees the old shape.
 
@@ -299,7 +307,7 @@ hub:
     webhooks:
       host: lunar.example.com
 
-# After (chart 2.0.0) — split-host (NEW capability)
+# After (chart 2.0.0) — split-host
 hub:
   # webhookURL derived as "https://webhooks.lunar.example.com".
   ingress:
@@ -320,11 +328,13 @@ hub:
 # component falls back to its own default (or warns at boot).
 hub:
   webhookURL: "https://lunar.example.com"
-  # Required when Grafana is reachable via external routing — otherwise
-  # GF_SERVER_ROOT_URL is empty and OIDC redirect_uris break.
-  grafanaURLBase: "https://grafana.example.com"
   ingress:
     enabled: false
+grafana:
+  # Required when grafana.enabled is true and the chart isn't managing
+  # Grafana's ingress — otherwise the install fails fast at template time
+  # (GF_SERVER_ROOT_URL empty → OIDC redirect_uris break).
+  externalURL: "https://grafana.example.com"
 ```
 
 ## Post-install
@@ -407,7 +417,8 @@ The central gRPC/HTTP server. Stores metadata, evaluates policies, and serves th
 | Key | Description | Default |
 |-----|-------------|---------|
 | `hub.webhookURL` | External URL where GitHub posts webhooks. Chart registers `<webhookURL>/webhooks/github` with the GitHub App at boot. Defaults to `https://<hub.ingress.webhooks.host>` **only when `hub.ingress.enabled: true`** — the chart only derives a URL when it actually routes the traffic. Set explicitly when ingress is disabled (BYO) or you need a non-default scheme/port/path. When set explicitly alongside chart-managed ingress, the host portion must equal `hub.ingress.webhooks.host` — install fails fast otherwise. | `""` (derived) |
-| `hub.grafanaURLBase` | Base URL where Grafana is reachable. Drives both `HUB_GRAFANA_URL_BASE` (`[More Details]` links in PR comments) and `GF_SERVER_ROOT_URL` (Grafana's self-knowledge — used for OIDC `redirect_uri` generation, absolute link rendering, etc). Defaults to `https://<grafana.ingress.hosts[0].host>` when chart-managed Grafana ingress is enabled. Empty otherwise — the chart only derives a URL when it actually controls the routing (no fallback to `webhookURL` or `api.host` — wrong trust boundary). Installs with externally-managed Grafana routing **must** set this explicitly, especially when Grafana fronts OIDC. | `""` (derived) |
+
+See also `grafana.externalURL` (under [Grafana](#grafana)) for the Grafana-side equivalent — drives both `HUB_GRAFANA_URL_BASE` (consumed by Hub) and `GF_SERVER_ROOT_URL` (consumed by Grafana).
 
 **Licence**
 
@@ -629,6 +640,7 @@ Pre-built Grafana instance with dashboards for policy results, component health,
 | Key | Description | Default |
 |-----|-------------|---------|
 | `grafana.enabled` | Deploy the pre-built Grafana instance | `true` |
+| `grafana.externalURL` | External URL where Grafana is reachable. Drives `GF_SERVER_ROOT_URL` (Grafana's self-knowledge — used for OIDC `redirect_uri`, absolute link rendering, etc) and `HUB_GRAFANA_URL_BASE` (`[More Details]` links in PR comments). Defaults to `https://<grafana.ingress.hosts[0].host>` when chart-managed Grafana ingress is enabled. Empty otherwise — the chart only derives a URL when it actually controls the routing (no fallback to `hub.webhookURL` or `hub.ingress.api.host` — wrong trust boundary). Installs with externally-managed Grafana routing **must** set this explicitly; otherwise install fails fast. | `""` (derived) |
 | `grafana.image.repository` | Grafana image | `ghcr.io/earthly/lunar-grafana` |
 | `grafana.image.tag` | Image tag | `2.1.1` |
 | `grafana.admin.secretName` | Secret containing both admin credentials. Empty = chart auto-generates `<release>-grafana-admin` (kept across uninstall) | `""` |

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: A Helm chart for Earthly Lunar 🌙
 type: application
-version: 1.0.2
+version: 2.0.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/NOTES.txt
+++ b/charts/lunar/templates/NOTES.txt
@@ -54,3 +54,24 @@ Retrieve any of them with:
 {{- end }}
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+URLs wired by the chart:
+
+{{- $webhookURL := include "lunar.webhookURL" . }}
+{{- $grafanaURL := include "lunar.grafanaURL" . }}
+{{- if $webhookURL }}
+  HUB_PUBLIC_BASE_URL    {{ $webhookURL }}
+  (GitHub registers webhooks at {{ $webhookURL }}/webhooks/github)
+{{- else }}
+  HUB_PUBLIC_BASE_URL    (unset — hub will warn at boot and skip webhook
+                         auto-registration. BYO-ingress installs should
+                         set hub.webhookURL.)
+{{- end }}
+{{- if .Values.grafana.enabled }}
+{{- if $grafanaURL }}
+  HUB_GRAFANA_URL_BASE   {{ $grafanaURL }}
+  GF_SERVER_ROOT_URL     {{ $grafanaURL }}
+{{- end }}
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/charts/lunar/templates/_helpers.tpl
+++ b/charts/lunar/templates/_helpers.tpl
@@ -137,6 +137,9 @@ cryptic render error or, worse, silently end up with no ingress at all.
 {{- if hasKey $h "publicBaseURL" -}}
 {{- fail "hub.publicBaseURL was renamed to hub.webhookURL in chart 2.0.0 (and is now optional — defaults to https://<hub.ingress.webhooks.host>). See README \"Migrating from chart 1.x\"." -}}
 {{- end -}}
+{{- if hasKey $h "grafanaURLBase" -}}
+{{- fail "hub.grafanaURLBase was renamed to grafana.externalURL in chart 2.0.0 (the value is a Grafana property; the hub consumes it, doesn't own it). See README \"Migrating from chart 1.x\"." -}}
+{{- end -}}
 {{- if or (hasKey $h.ingress "host") (hasKey $h.ingress "grpcAnnotations") (hasKey $h.ingress "httpAnnotations") -}}
 {{- fail "hub.ingress shape changed in chart 2.0.0. Move 'host' under api.host AND webhooks.host. Move 'grpcAnnotations'/'httpAnnotations' under api.grpcAnnotations/api.httpAnnotations. See README \"Migrating from chart 1.x\"." -}}
 {{- end -}}
@@ -166,28 +169,51 @@ Consumed by hub-deployment.yaml as HUB_PUBLIC_BASE_URL.
 {{/*
 Effective base URL for Grafana. Resolution chain (highest priority first):
 
-  1. hub.grafanaURLBase                       explicit override
+  1. grafana.externalURL                      explicit override
   2. https://<grafana.ingress.hosts[0].host>  chart-managed Grafana ingress
 
 Empty otherwise — the chart only derives a URL when it actually controls
 the routing. Deliberately does NOT guess based on hub.ingress.api.host
 (chart doesn't route Grafana traffic there) or hub.webhookURL (wrong
 trust boundary). Installs that expose Grafana via external routing
-MUST set hub.grafanaURLBase explicitly, especially when Grafana fronts
+MUST set grafana.externalURL explicitly, especially when Grafana fronts
 OIDC (otherwise redirect_uri is wrong or empty).
 
 Consumed by hub-deployment.yaml as HUB_GRAFANA_URL_BASE and by
 grafana-deployment.yaml as GF_SERVER_ROOT_URL.
 */}}
 {{- define "lunar.grafanaURL" -}}
-{{- $hub := .Values.hub -}}
-{{- $grafanaIng := .Values.grafana.ingress -}}
+{{- $grafana := .Values.grafana -}}
+{{- $grafanaIng := $grafana.ingress -}}
 {{- $grafanaHost := "" -}}
 {{- if and $grafanaIng.enabled $grafanaIng.hosts -}}
 {{- $grafanaHost = (index $grafanaIng.hosts 0).host -}}
 {{- end -}}
-{{- if $hub.grafanaURLBase -}}{{ $hub.grafanaURLBase }}
+{{- if $grafana.externalURL -}}{{ $grafana.externalURL }}
 {{- else if $grafanaHost -}}{{ printf "https://%s" $grafanaHost }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Fail fast when grafana.enabled is true but the chart can't determine a
+Grafana URL. Specifically catches the 1.x "Caddy / content-routing"
+upgrader: in 1.x, GF_SERVER_ROOT_URL and HUB_GRAFANA_URL_BASE both
+defaulted to publicBaseURL. 2.0.0 deliberately drops that fallback —
+guessing at a URL the chart doesn't route to is wrong. Without this
+guard, upgraders silently end up with GF_SERVER_ROOT_URL unset →
+Grafana defaults to http://localhost:3000/ → OIDC redirect_uri breaks.
+
+Three escape hatches, depending on topology:
+  - Set grafana.externalURL (BYO ingress / Caddy / external routing)
+  - Enable grafana.ingress (chart-managed Grafana ingress)
+  - Set grafana.enabled: false (skip Grafana entirely)
+*/}}
+{{- define "lunar.validateGrafana" -}}
+{{- if .Values.grafana.enabled -}}
+  {{- $url := include "lunar.grafanaURL" . -}}
+  {{- if not $url -}}
+    {{- fail "grafana.externalURL is required when grafana.enabled is true and the chart doesn't manage Grafana's ingress (chart 2.0.0 no longer derives Grafana URLs it doesn't route to — see README \"Migrating from chart 1.x\" for the Caddy / content-routing case). Pick one:\n  - grafana.externalURL = \"<your Grafana URL>\"  (BYO ingress / Caddy / external routing)\n  - grafana.ingress.enabled = true              (chart-managed Grafana ingress)\n  - grafana.enabled = false                     (skip Grafana entirely)" -}}
+  {{- end -}}
 {{- end -}}
 {{- end }}
 

--- a/charts/lunar/templates/_helpers.tpl
+++ b/charts/lunar/templates/_helpers.tpl
@@ -126,3 +126,109 @@ particular). Callers that need to honor a per-component override should do
 {{- define "lunar.hubHost" -}}
 {{- printf "%s-hub.%s.svc.%s" (include "lunar.fullname" .) .Release.Namespace .Values.clusterDomain -}}
 {{- end }}
+
+{{/*
+Reject chart 1.x ingress shape early with a migration message. Anyone
+upgrading from 1.x with their old values intact would otherwise get a
+cryptic render error or, worse, silently end up with no ingress at all.
+*/}}
+{{- define "lunar.rejectLegacyIngressShape" -}}
+{{- $h := .Values.hub -}}
+{{- if hasKey $h "publicBaseURL" -}}
+{{- fail "hub.publicBaseURL was renamed to hub.webhookURL in chart 2.0.0 (and now defaults to https://<hub.ingress.webhooks.host>). See README \"Migrating from chart 1.x\"." -}}
+{{- end -}}
+{{- if or (hasKey $h.ingress "host") (hasKey $h.ingress "grpcAnnotations") (hasKey $h.ingress "httpAnnotations") -}}
+{{- fail "hub.ingress shape changed in chart 2.0.0. Move 'host' under api.host AND webhooks.host. Move 'grpcAnnotations'/'httpAnnotations' under api.grpcAnnotations/api.httpAnnotations. See README \"Migrating from chart 1.x\"." -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Effective external URL where GitHub posts webhooks. Falls back to
+"https://<hub.ingress.webhooks.host>" when not explicitly set and the
+chart's ingress is enabled. Empty when neither is configured — lunar
+itself warns at boot in that case.
+
+Consumed by hub-deployment.yaml as HUB_PUBLIC_BASE_URL (lunar env var
+name preserved from chart 1.x).
+*/}}
+{{- define "lunar.webhookURL" -}}
+{{- $hub := .Values.hub -}}
+{{- if $hub.webhookURL -}}
+{{- $hub.webhookURL -}}
+{{- else if and $hub.ingress.enabled $hub.ingress.webhooks.host -}}
+{{- printf "https://%s" $hub.ingress.webhooks.host -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Fail fast on ingress misconfiguration: missing required hosts when
+ingress is enabled, and (when the user explicitly overrides webhookURL)
+a webhookURL host that doesn't match webhooks.host.
+*/}}
+{{- define "lunar.validateIngress" -}}
+{{- $hub := .Values.hub -}}
+{{- if $hub.ingress.enabled -}}
+  {{- if not $hub.ingress.api.host -}}
+    {{- fail "hub.ingress.api.host is required when hub.ingress.enabled is true." -}}
+  {{- end -}}
+  {{- if not $hub.ingress.webhooks.host -}}
+    {{- fail "hub.ingress.webhooks.host is required when hub.ingress.enabled is true." -}}
+  {{- end -}}
+  {{- if $hub.webhookURL -}}
+    {{- $parsed := urlParse $hub.webhookURL -}}
+    {{- if not $parsed.host -}}
+      {{- fail (printf "hub.webhookURL %q must be a full URL including scheme (e.g. https://webhooks.example.com)." $hub.webhookURL) -}}
+    {{- end -}}
+    {{- $publicHost := lower (regexReplaceAll ":\\d+$" $parsed.host "") -}}
+    {{- $webhookHost := lower $hub.ingress.webhooks.host -}}
+    {{- if ne $publicHost $webhookHost -}}
+      {{- fail (printf "hub.webhookURL host (%q) must equal hub.ingress.webhooks.host (%q). GitHub POSTs to webhookURL/webhooks/github and must reach the webhooks ingress." $publicHost $webhookHost) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolve per-ingress className. Block-level value wins; falls back to
+the shared ingress.className default. Empty is allowed (no className
+rendered).
+
+Usage:
+  {{ include "lunar.ingress.className" (dict "shared" .Values.hub.ingress.className "block" .Values.hub.ingress.api.className) }}
+*/}}
+{{- define "lunar.ingress.className" -}}
+{{- default .shared .block -}}
+{{- end }}
+
+{{/*
+Resolve per-ingress TLS list. Block-level list wins when non-empty;
+otherwise falls back to ingress.tls. Empty list passes through.
+
+Usage:
+  {{ include "lunar.ingress.tls" (dict "shared" .Values.hub.ingress.tls "block" .Values.hub.ingress.api.tls) }}
+*/}}
+{{- define "lunar.ingress.tls" -}}
+{{- if .block -}}
+{{- toYaml .block -}}
+{{- else -}}
+{{- toYaml .shared -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolve per-ingress annotations by deep-merging the shared, block, and
+optional sub-block layers in priority order (deepest wins). Sub-block
+is used for api.grpcAnnotations / api.httpAnnotations.
+
+Usage:
+  {{ include "lunar.ingress.annotations" (dict "shared" .Values.hub.ingress.annotations "block" .Values.hub.ingress.api.annotations "sub" .Values.hub.ingress.api.grpcAnnotations) }}
+*/}}
+{{- define "lunar.ingress.annotations" -}}
+{{- $sub := default (dict) .sub -}}
+{{- $block := default (dict) .block -}}
+{{- $shared := default (dict) .shared -}}
+{{- $merged := merge (deepCopy $sub) $block $shared -}}
+{{- if $merged -}}
+{{- toYaml $merged -}}
+{{- end -}}
+{{- end }}

--- a/charts/lunar/templates/_helpers.tpl
+++ b/charts/lunar/templates/_helpers.tpl
@@ -135,21 +135,24 @@ cryptic render error or, worse, silently end up with no ingress at all.
 {{- define "lunar.rejectLegacyIngressShape" -}}
 {{- $h := .Values.hub -}}
 {{- if hasKey $h "publicBaseURL" -}}
-{{- fail "hub.publicBaseURL was renamed to hub.webhookURL in chart 2.0.0 (and now defaults to https://<hub.ingress.webhooks.host>). See README \"Migrating from chart 1.x\"." -}}
+{{- fail "hub.publicBaseURL was renamed to hub.webhookURL in chart 2.0.0 (and is now optional — defaults to https://<hub.ingress.webhooks.host>). See README \"Migrating from chart 1.x\"." -}}
 {{- end -}}
 {{- if or (hasKey $h.ingress "host") (hasKey $h.ingress "grpcAnnotations") (hasKey $h.ingress "httpAnnotations") -}}
 {{- fail "hub.ingress shape changed in chart 2.0.0. Move 'host' under api.host AND webhooks.host. Move 'grpcAnnotations'/'httpAnnotations' under api.grpcAnnotations/api.httpAnnotations. See README \"Migrating from chart 1.x\"." -}}
 {{- end -}}
+{{- if hasKey $h.ingress.api "annotations" -}}
+{{- fail "hub.ingress.api.annotations is not a chart value. Per-Ingress annotations go in hub.ingress.api.grpcAnnotations and hub.ingress.api.httpAnnotations (the chart collapsed the middle layer to keep the merge contract simple). Annotations shared with the webhooks Ingress go in hub.ingress.annotations." -}}
+{{- end -}}
 {{- end }}
 
 {{/*
-Effective external URL where GitHub posts webhooks. Falls back to
-"https://<hub.ingress.webhooks.host>" when not explicitly set and the
-chart's ingress is enabled. Empty when neither is configured — lunar
-itself warns at boot in that case.
+Effective external URL where GitHub posts webhooks. hub.webhookURL when
+set; otherwise derived from hub.ingress.webhooks.host ONLY when chart-
+managed ingress is enabled (the chart only derives a URL when it
+actually routes traffic at that host). Empty otherwise — BYO-ingress
+installs must set hub.webhookURL explicitly.
 
-Consumed by hub-deployment.yaml as HUB_PUBLIC_BASE_URL (lunar env var
-name preserved from chart 1.x).
+Consumed by hub-deployment.yaml as HUB_PUBLIC_BASE_URL.
 */}}
 {{- define "lunar.webhookURL" -}}
 {{- $hub := .Values.hub -}}
@@ -161,47 +164,54 @@ name preserved from chart 1.x).
 {{- end }}
 
 {{/*
-Effective base URL for Grafana — used by hub to build [More Details]
-links in PR comments. Resolution chain (highest priority first):
+Effective base URL for Grafana. Resolution chain (highest priority first):
 
-  1. hub.grafanaURLBase explicit override
-  2. https://<grafana.ingress.hosts[0].host>  when chart manages Grafana's ingress
-  3. https://<hub.ingress.api.host>           when chart manages Hub's ingress
-  4. lunar.webhookURL                         BYO fallback
+  1. hub.grafanaURLBase                       explicit override
+  2. https://<grafana.ingress.hosts[0].host>  chart-managed Grafana ingress
 
-The api.host fallback (#3) is the correct trust boundary for human-facing
-Grafana — same network as lunar CLI / CI agent traffic — even when no
-path-routing is configured there. Customers in non-trivial topologies
-should set grafanaURLBase explicitly.
+Empty otherwise — the chart only derives a URL when it actually controls
+the routing. Deliberately does NOT guess based on hub.ingress.api.host
+(chart doesn't route Grafana traffic there) or hub.webhookURL (wrong
+trust boundary). Installs that expose Grafana via external routing
+MUST set hub.grafanaURLBase explicitly, especially when Grafana fronts
+OIDC (otherwise redirect_uri is wrong or empty).
 
-Consumed by hub-deployment.yaml as HUB_GRAFANA_URL_BASE.
+Consumed by hub-deployment.yaml as HUB_GRAFANA_URL_BASE and by
+grafana-deployment.yaml as GF_SERVER_ROOT_URL.
 */}}
 {{- define "lunar.grafanaURL" -}}
 {{- $hub := .Values.hub -}}
-{{- $grafana := .Values.grafana -}}
-{{- if $hub.grafanaURLBase -}}
-{{- $hub.grafanaURLBase -}}
-{{- else if and $grafana.ingress.enabled $grafana.ingress.hosts -}}
-{{- $firstHost := (index $grafana.ingress.hosts 0).host -}}
-{{- if $firstHost -}}
-{{- printf "https://%s" $firstHost -}}
-{{- else -}}
-{{- include "lunar.webhookURL" . -}}
+{{- $grafanaIng := .Values.grafana.ingress -}}
+{{- $grafanaHost := "" -}}
+{{- if and $grafanaIng.enabled $grafanaIng.hosts -}}
+{{- $grafanaHost = (index $grafanaIng.hosts 0).host -}}
 {{- end -}}
-{{- else if and $hub.ingress.enabled $hub.ingress.api.host -}}
-{{- printf "https://%s" $hub.ingress.api.host -}}
-{{- else -}}
-{{- include "lunar.webhookURL" . -}}
+{{- if $hub.grafanaURLBase -}}{{ $hub.grafanaURLBase }}
+{{- else if $grafanaHost -}}{{ printf "https://%s" $grafanaHost }}
 {{- end -}}
 {{- end }}
 
 {{/*
-Fail fast on ingress misconfiguration: missing required hosts when
-ingress is enabled, and (when the user explicitly overrides webhookURL)
-a webhookURL host that doesn't match webhooks.host.
+Fail fast on ingress misconfiguration:
+  - hub.webhookURL (whenever set) must be a full URL with scheme. This
+    fires for BYO ingress too, where it matters most — a bare hostname
+    in HUB_PUBLIC_BASE_URL silently breaks webhook registration.
+  - When chart-managed ingress is enabled, api.host and webhooks.host
+    are required.
+  - When both webhookURL and webhooks.host are set, host portions must
+    match — otherwise GitHub POSTs into the void.
 */}}
 {{- define "lunar.validateIngress" -}}
 {{- $hub := .Values.hub -}}
+{{- if $hub.webhookURL -}}
+  {{- $parsed := urlParse $hub.webhookURL -}}
+  {{- if not $parsed.host -}}
+    {{- fail (printf "hub.webhookURL %q must be a full URL including scheme (e.g. https://webhooks.example.com)." $hub.webhookURL) -}}
+  {{- end -}}
+  {{- if not (has $parsed.scheme (list "http" "https")) -}}
+    {{- fail (printf "hub.webhookURL %q has unsupported scheme %q. GitHub webhook URLs must be http or https." $hub.webhookURL $parsed.scheme) -}}
+  {{- end -}}
+{{- end -}}
 {{- if $hub.ingress.enabled -}}
   {{- if not $hub.ingress.api.host -}}
     {{- fail "hub.ingress.api.host is required when hub.ingress.enabled is true." -}}
@@ -211,9 +221,6 @@ a webhookURL host that doesn't match webhooks.host.
   {{- end -}}
   {{- if $hub.webhookURL -}}
     {{- $parsed := urlParse $hub.webhookURL -}}
-    {{- if not $parsed.host -}}
-      {{- fail (printf "hub.webhookURL %q must be a full URL including scheme (e.g. https://webhooks.example.com)." $hub.webhookURL) -}}
-    {{- end -}}
     {{- $publicHost := lower (regexReplaceAll ":\\d+$" $parsed.host "") -}}
     {{- $webhookHost := lower $hub.ingress.webhooks.host -}}
     {{- if ne $publicHost $webhookHost -}}
@@ -224,45 +231,17 @@ a webhookURL host that doesn't match webhooks.host.
 {{- end }}
 
 {{/*
-Resolve per-ingress className. Block-level value wins; falls back to
-the shared ingress.className default. Empty is allowed (no className
-rendered).
+Resolve per-ingress annotations by merging the per-Ingress map on top
+of the shared ingress.annotations default. Per-Ingress wins on key
+collision.
 
 Usage:
-  {{ include "lunar.ingress.className" (dict "shared" .Values.hub.ingress.className "block" .Values.hub.ingress.api.className) }}
-*/}}
-{{- define "lunar.ingress.className" -}}
-{{- default .shared .block -}}
-{{- end }}
-
-{{/*
-Resolve per-ingress TLS list. Block-level list wins when non-empty;
-otherwise falls back to ingress.tls. Empty list passes through.
-
-Usage:
-  {{ include "lunar.ingress.tls" (dict "shared" .Values.hub.ingress.tls "block" .Values.hub.ingress.api.tls) }}
-*/}}
-{{- define "lunar.ingress.tls" -}}
-{{- if .block -}}
-{{- toYaml .block -}}
-{{- else -}}
-{{- toYaml .shared -}}
-{{- end -}}
-{{- end }}
-
-{{/*
-Resolve per-ingress annotations by deep-merging the shared, block, and
-optional sub-block layers in priority order (deepest wins). Sub-block
-is used for api.grpcAnnotations / api.httpAnnotations.
-
-Usage:
-  {{ include "lunar.ingress.annotations" (dict "shared" .Values.hub.ingress.annotations "block" .Values.hub.ingress.api.annotations "sub" .Values.hub.ingress.api.grpcAnnotations) }}
+  {{ include "lunar.ingress.annotations" (dict "shared" .Values.hub.ingress.annotations "specific" .Values.hub.ingress.api.grpcAnnotations) }}
 */}}
 {{- define "lunar.ingress.annotations" -}}
-{{- $sub := default (dict) .sub -}}
-{{- $block := default (dict) .block -}}
+{{- $specific := default (dict) .specific -}}
 {{- $shared := default (dict) .shared -}}
-{{- $merged := merge (deepCopy $sub) $block $shared -}}
+{{- $merged := merge (deepCopy $specific) $shared -}}
 {{- if $merged -}}
 {{- toYaml $merged -}}
 {{- end -}}

--- a/charts/lunar/templates/_helpers.tpl
+++ b/charts/lunar/templates/_helpers.tpl
@@ -161,6 +161,41 @@ name preserved from chart 1.x).
 {{- end }}
 
 {{/*
+Effective base URL for Grafana — used by hub to build [More Details]
+links in PR comments. Resolution chain (highest priority first):
+
+  1. hub.grafanaURLBase explicit override
+  2. https://<grafana.ingress.hosts[0].host>  when chart manages Grafana's ingress
+  3. https://<hub.ingress.api.host>           when chart manages Hub's ingress
+  4. lunar.webhookURL                         BYO fallback
+
+The api.host fallback (#3) is the correct trust boundary for human-facing
+Grafana — same network as lunar CLI / CI agent traffic — even when no
+path-routing is configured there. Customers in non-trivial topologies
+should set grafanaURLBase explicitly.
+
+Consumed by hub-deployment.yaml as HUB_GRAFANA_URL_BASE.
+*/}}
+{{- define "lunar.grafanaURL" -}}
+{{- $hub := .Values.hub -}}
+{{- $grafana := .Values.grafana -}}
+{{- if $hub.grafanaURLBase -}}
+{{- $hub.grafanaURLBase -}}
+{{- else if and $grafana.ingress.enabled $grafana.ingress.hosts -}}
+{{- $firstHost := (index $grafana.ingress.hosts 0).host -}}
+{{- if $firstHost -}}
+{{- printf "https://%s" $firstHost -}}
+{{- else -}}
+{{- include "lunar.webhookURL" . -}}
+{{- end -}}
+{{- else if and $hub.ingress.enabled $hub.ingress.api.host -}}
+{{- printf "https://%s" $hub.ingress.api.host -}}
+{{- else -}}
+{{- include "lunar.webhookURL" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Fail fast on ingress misconfiguration: missing required hosts when
 ingress is enabled, and (when the user explicitly overrides webhookURL)
 a webhookURL host that doesn't match webhooks.host.

--- a/charts/lunar/templates/grafana-deployment.yaml
+++ b/charts/lunar/templates/grafana-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.grafana.enabled -}}
+{{- $grafanaURL := include "lunar.grafanaURL" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -63,10 +64,8 @@ spec:
               value: {{ include "lunar.hubHost" $ | quote }}
             - name: LUNAR_HUB_HTTP_PORT
               value: {{ $.Values.hub.service.ports.http | quote }}
-            {{- if $.Values.hub.publicBaseURL }}
             - name: GF_SERVER_ROOT_URL
-              value: {{ $.Values.hub.publicBaseURL | quote }}
-            {{- end }}
+              value: {{ $grafanaURL | quote }}
             - name: LUNAR_HUB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/lunar/templates/grafana-deployment.yaml
+++ b/charts/lunar/templates/grafana-deployment.yaml
@@ -64,8 +64,10 @@ spec:
               value: {{ include "lunar.hubHost" $ | quote }}
             - name: LUNAR_HUB_HTTP_PORT
               value: {{ $.Values.hub.service.ports.http | quote }}
+            {{- with $grafanaURL }}
             - name: GF_SERVER_ROOT_URL
-              value: {{ $grafanaURL | quote }}
+              value: {{ . | quote }}
+            {{- end }}
             - name: LUNAR_HUB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -1,6 +1,7 @@
 {{- include "lunar.githubAuthCheck" . }}
 {{- include "lunar.hubLicenceCheck" . }}
 {{- include "lunar.rejectLegacyIngressShape" . }}
+{{- include "lunar.validateGrafana" . }}
 {{- $webhookURL := include "lunar.webhookURL" . -}}
 {{- $grafanaURL := include "lunar.grafanaURL" . -}}
 apiVersion: apps/v1

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -1,5 +1,7 @@
 {{- include "lunar.githubAuthCheck" . }}
 {{- include "lunar.hubLicenceCheck" . }}
+{{- include "lunar.rejectLegacyIngressShape" . }}
+{{- $webhookURL := include "lunar.webhookURL" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -135,14 +137,10 @@ spec:
               value: {{ .s3.logsUrlTtl | quote }}
             - name: HUB_RESOURCES_AWS_URL_TTL
               value: {{ .s3.resourcesUrlTtl | quote }}
-            {{- if .publicBaseURL }}
             - name: HUB_PUBLIC_BASE_URL
-              value: {{ .publicBaseURL | quote }}
-            {{- end }}
-            {{- with (or .grafanaURLBase .publicBaseURL) }}
+              value: {{ $webhookURL | quote }}
             - name: HUB_GRAFANA_URL_BASE
-              value: {{ . | quote }}
-            {{- end }}
+              value: {{ default $webhookURL .grafanaURLBase | quote }}
             - name: HUB_K8S_EXECUTION_ENABLED
               value: "true"
             - name: HUB_MAX_WORKERS_COLLECT

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -2,6 +2,7 @@
 {{- include "lunar.hubLicenceCheck" . }}
 {{- include "lunar.rejectLegacyIngressShape" . }}
 {{- $webhookURL := include "lunar.webhookURL" . -}}
+{{- $grafanaURL := include "lunar.grafanaURL" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -140,7 +141,7 @@ spec:
             - name: HUB_PUBLIC_BASE_URL
               value: {{ $webhookURL | quote }}
             - name: HUB_GRAFANA_URL_BASE
-              value: {{ default $webhookURL .grafanaURLBase | quote }}
+              value: {{ $grafanaURL | quote }}
             - name: HUB_K8S_EXECUTION_ENABLED
               value: "true"
             - name: HUB_MAX_WORKERS_COLLECT

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -138,10 +138,14 @@ spec:
               value: {{ .s3.logsUrlTtl | quote }}
             - name: HUB_RESOURCES_AWS_URL_TTL
               value: {{ .s3.resourcesUrlTtl | quote }}
+            {{- with $webhookURL }}
             - name: HUB_PUBLIC_BASE_URL
-              value: {{ $webhookURL | quote }}
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $grafanaURL }}
             - name: HUB_GRAFANA_URL_BASE
-              value: {{ $grafanaURL | quote }}
+              value: {{ . | quote }}
+            {{- end }}
             - name: HUB_K8S_EXECUTION_ENABLED
               value: "true"
             - name: HUB_MAX_WORKERS_COLLECT

--- a/charts/lunar/templates/hub-ingress.yaml
+++ b/charts/lunar/templates/hub-ingress.yaml
@@ -1,84 +1,122 @@
 {{/*
-Hub ingress is split into two Ingress resources because hub serves
-gRPC (port 8000, used by CLI / CI agents / operator) and HTTP (port 8001,
-GitHub webhooks + log redirects) on separate ports, and most ingress
-controllers (NGINX especially) apply backend-protocol annotations
-per-Ingress, not per-path. Same shape as Argo CD's chart.
+Hub is reached over three distinct traffic patterns:
+  - gRPC API on hub:8000 (CLI / CI agents / operator). backend-protocol: GRPC.
+  - HTTP /logs on hub:8001 (lunar-ci-agent log uploads, auth'd). HTTP/1.1.
+  - HTTP /webhooks on hub:8001 (GitHub webhooks). HTTP/1.1.
 
-Both ingresses share host + className + TLS; per-protocol annotations
-are merged on top of the common annotations.
+The first two share a trust boundary ("trusted API clients"); the third
+is the public-internet ingress. The chart groups them under two logical
+values blocks (hub.ingress.api, hub.ingress.webhooks) but renders THREE
+Ingress resources because most controllers apply backend-protocol
+annotations per-Ingress, not per-path:
+
+  - <release>-hub-api-grpc   host=api.host       backend-protocol=GRPC
+  - <release>-hub-api-http   host=api.host       backend-protocol=HTTP
+  - <release>-hub-webhooks   host=webhooks.host  backend-protocol=HTTP
+
+The webhooks.host must equal the host portion of hub.webhookURL (which
+itself defaults to https://<webhooks.host>). The chart enforces this.
 */}}
+{{- include "lunar.rejectLegacyIngressShape" . -}}
+{{- include "lunar.validateIngress" . -}}
 {{- if .Values.hub.ingress.enabled -}}
+{{- $fullname := include "lunar.fullname" . -}}
 {{- $hub := .Values.hub -}}
-{{- if not $hub.ingress.host -}}
-{{- fail "hub.ingress.host is required when hub.ingress.enabled is true." -}}
-{{- end -}}
-{{- $grpcAnnotations := merge (deepCopy $hub.ingress.grpcAnnotations) $hub.ingress.annotations -}}
+{{- $ing := $hub.ingress -}}
+{{- $apiClassName := include "lunar.ingress.className" (dict "shared" $ing.className "block" $ing.api.className) -}}
+{{- $apiTLS := include "lunar.ingress.tls" (dict "shared" $ing.tls "block" $ing.api.tls) -}}
+{{- $apiGrpcAnnotations := include "lunar.ingress.annotations" (dict "shared" $ing.annotations "block" $ing.api.annotations "sub" $ing.api.grpcAnnotations) -}}
+{{- $apiHttpAnnotations := include "lunar.ingress.annotations" (dict "shared" $ing.annotations "block" $ing.api.annotations "sub" $ing.api.httpAnnotations) -}}
+{{- $webhooksClassName := include "lunar.ingress.className" (dict "shared" $ing.className "block" $ing.webhooks.className) -}}
+{{- $webhooksTLS := include "lunar.ingress.tls" (dict "shared" $ing.tls "block" $ing.webhooks.tls) -}}
+{{- $webhooksAnnotations := include "lunar.ingress.annotations" (dict "shared" $ing.annotations "block" $ing.webhooks.annotations) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "lunar.fullname" . }}-hub-grpc
+  name: {{ $fullname }}-hub-api-grpc
   labels:
     {{- include "lunar.labels" . | nindent 4 }}
-  {{- with $grpcAnnotations }}
+  {{- with $apiGrpcAnnotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with $hub.ingress.className }}
+  {{- with $apiClassName }}
   ingressClassName: {{ . }}
   {{- end }}
-  {{- with $hub.ingress.tls }}
+  {{- with $apiTLS }}
   tls:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
   rules:
-    - host: {{ $hub.ingress.host | quote }}
+    - host: {{ $ing.api.host | quote }}
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: {{ include "lunar.fullname" . }}-hub
+                name: {{ $fullname }}-hub
                 port:
                   name: hub-grpc
 ---
-{{- $httpAnnotations := merge (deepCopy $hub.ingress.httpAnnotations) $hub.ingress.annotations }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "lunar.fullname" . }}-hub-http
+  name: {{ $fullname }}-hub-api-http
   labels:
     {{- include "lunar.labels" . | nindent 4 }}
-  {{- with $httpAnnotations }}
+  {{- with $apiHttpAnnotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with $hub.ingress.className }}
+  {{- with $apiClassName }}
   ingressClassName: {{ . }}
   {{- end }}
-  {{- with $hub.ingress.tls }}
+  {{- with $apiTLS }}
   tls:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
   rules:
-    - host: {{ $hub.ingress.host | quote }}
+    - host: {{ $ing.api.host | quote }}
+      http:
+        paths:
+          - path: /logs
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullname }}-hub
+                port:
+                  name: hub-http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullname }}-hub-webhooks
+  labels:
+    {{- include "lunar.labels" . | nindent 4 }}
+  {{- with $webhooksAnnotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $webhooksClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with $webhooksTLS }}
+  tls:
+    {{- . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ $ing.webhooks.host | quote }}
       http:
         paths:
           - path: /webhooks
             pathType: Prefix
             backend:
               service:
-                name: {{ include "lunar.fullname" . }}-hub
-                port:
-                  name: hub-http
-          - path: /logs
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "lunar.fullname" . }}-hub
+                name: {{ $fullname }}-hub
                 port:
                   name: hub-http
 {{- end }}

--- a/charts/lunar/templates/hub-ingress.yaml
+++ b/charts/lunar/templates/hub-ingress.yaml
@@ -23,13 +23,13 @@ itself defaults to https://<webhooks.host>). The chart enforces this.
 {{- $fullname := include "lunar.fullname" . -}}
 {{- $hub := .Values.hub -}}
 {{- $ing := $hub.ingress -}}
-{{- $apiClassName := include "lunar.ingress.className" (dict "shared" $ing.className "block" $ing.api.className) -}}
-{{- $apiTLS := include "lunar.ingress.tls" (dict "shared" $ing.tls "block" $ing.api.tls) -}}
-{{- $apiGrpcAnnotations := include "lunar.ingress.annotations" (dict "shared" $ing.annotations "block" $ing.api.annotations "sub" $ing.api.grpcAnnotations) -}}
-{{- $apiHttpAnnotations := include "lunar.ingress.annotations" (dict "shared" $ing.annotations "block" $ing.api.annotations "sub" $ing.api.httpAnnotations) -}}
-{{- $webhooksClassName := include "lunar.ingress.className" (dict "shared" $ing.className "block" $ing.webhooks.className) -}}
-{{- $webhooksTLS := include "lunar.ingress.tls" (dict "shared" $ing.tls "block" $ing.webhooks.tls) -}}
-{{- $webhooksAnnotations := include "lunar.ingress.annotations" (dict "shared" $ing.annotations "block" $ing.webhooks.annotations) -}}
+{{- $apiClassName := default $ing.className $ing.api.className -}}
+{{- $apiTLS := default $ing.tls $ing.api.tls -}}
+{{- $apiGrpcAnnotations := include "lunar.ingress.annotations" (dict "shared" $ing.annotations "specific" $ing.api.grpcAnnotations) -}}
+{{- $apiHttpAnnotations := include "lunar.ingress.annotations" (dict "shared" $ing.annotations "specific" $ing.api.httpAnnotations) -}}
+{{- $webhooksClassName := default $ing.className $ing.webhooks.className -}}
+{{- $webhooksTLS := default $ing.tls $ing.webhooks.tls -}}
+{{- $webhooksAnnotations := include "lunar.ingress.annotations" (dict "shared" $ing.annotations "specific" $ing.webhooks.annotations) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -46,7 +46,7 @@ spec:
   {{- end }}
   {{- with $apiTLS }}
   tls:
-    {{- . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - host: {{ $ing.api.host | quote }}
@@ -76,7 +76,7 @@ spec:
   {{- end }}
   {{- with $apiTLS }}
   tls:
-    {{- . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - host: {{ $ing.api.host | quote }}
@@ -106,7 +106,7 @@ spec:
   {{- end }}
   {{- with $webhooksTLS }}
   tls:
-    {{- . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - host: {{ $ing.webhooks.host | quote }}

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -28,14 +28,21 @@ hub:
   # External URL where GitHub posts webhooks. Hub registers
   # <webhookURL>/webhooks/github with the GitHub App at boot.
   #
-  # Defaults to "https://<hub.ingress.webhooks.host>" when ingress.enabled
-  # is true — most installs leave this empty and let the chart derive it.
+  # Defaults to "https://<hub.ingress.webhooks.host>" ONLY when chart-
+  # managed ingress is enabled — that's the case where the chart actually
+  # routes traffic at that host. Most chart-managed installs leave this
+  # empty and let the chart derive it.
+  #
   # Set explicitly when:
-  #   - hub.ingress.enabled is false (BYO ingress / LoadBalancer / mesh),
-  #   - you need a non-default scheme (http for dev), port, or path prefix.
+  #   - hub.ingress.enabled is false (BYO ingress / LoadBalancer / mesh).
+  #     The chart will not guess a URL it doesn't route to; if you leave
+  #     this empty in BYO mode, HUB_PUBLIC_BASE_URL is empty and the hub
+  #     warns at boot and skips webhook auto-registration.
+  #   - You need a non-default scheme (http for dev), port, or path prefix.
   #
   # When set explicitly AND hub.ingress.enabled is true, the host portion
-  # must equal hub.ingress.webhooks.host.
+  # must equal hub.ingress.webhooks.host. The chart fails fast otherwise —
+  # GitHub would POST into the void.
   webhookURL: ""
 
   # Base URL where Grafana is reachable. Used for two distinct purposes:
@@ -44,16 +51,14 @@ hub:
   #     link generation, OIDC redirect_uri, etc). Critical to get right when
   #     Grafana fronts third-party auth (Google, Okta, GitHub OIDC, ...).
   #
-  # Resolution chain when empty (highest priority first):
-  #   1. https://<grafana.ingress.hosts[0].host>  when chart manages Grafana's ingress
-  #   2. https://<hub.ingress.api.host>           when chart manages Hub's ingress
-  #   3. hub.webhookURL                           BYO fallback
+  # Defaults to https://<grafana.ingress.hosts[0].host> when chart-managed
+  # Grafana ingress is enabled — most installs just turn that on and leave
+  # this empty. Empty otherwise — the chart deliberately does NOT guess at
+  # a Grafana URL when it doesn't control the routing (no fallback to
+  # webhookURL or api.host — wrong trust boundary, wrong host).
   #
-  # The api.host fallback is deliberate: Grafana is a human-facing dashboard
-  # accessed from internal browsers — same trust boundary as lunar CLI / CI
-  # agent traffic, NOT the public webhooks ingress. Set explicitly when
-  # Grafana lives on a hostname none of these capture (separate ingress that
-  # isn't chart-managed, external Grafana, etc).
+  # Set explicitly when Grafana is reachable via external routing the chart
+  # doesn't manage. Required for OIDC to work in that topology.
   grafanaURLBase: ""
 
   rootDir: /hub/
@@ -226,19 +231,22 @@ hub:
       host: ""
 
       # Optional per-ingress overrides of the shared defaults above.
-      className: ""    # empty -> falls back to ingress.className
-      tls: []          # empty -> falls back to ingress.tls
-      annotations: {}  # merged on top of ingress.annotations
+      # Empty values fall back to ingress.className / ingress.tls.
+      className: ""
+      tls: []
 
-      # Per-sub-Ingress annotations within the api block. NGINX users
-      # almost always need backend-protocol: "GRPC" for the gRPC half.
+      # Per-sub-Ingress annotations, layered on top of ingress.annotations.
+      # NGINX users almost always need backend-protocol: "GRPC" for the gRPC
+      # half. To add the same annotation to BOTH api Ingresses, either put it
+      # in ingress.annotations (shared with webhooks too) or duplicate it under
+      # both maps below.
       grpcAnnotations:
         nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
       httpAnnotations: {}
 
     # Webhooks ingress: GitHub webhook receiver only. Public-facing.
     # Lock this down to /webhooks if you want — nothing else lives here.
-    # Also the source of truth for the derived hub.webhookURL.
+    # Also the source of the derived hub.webhookURL (https://<host>).
     webhooks:
       # Required when ingress.enabled is true.
       host: ""

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -38,8 +38,13 @@ hub:
   # must equal hub.ingress.webhooks.host.
   webhookURL: ""
 
-  # Base URL the hub uses for [More Details] links in PR comments. Resolution
-  # chain when empty (highest priority first):
+  # Base URL where Grafana is reachable. Used for two distinct purposes:
+  #   - HUB_GRAFANA_URL_BASE — base for hub's [More Details] links in PR comments
+  #   - GF_SERVER_ROOT_URL — Grafana's own self-knowledge (drives absolute
+  #     link generation, OIDC redirect_uri, etc). Critical to get right when
+  #     Grafana fronts third-party auth (Google, Okta, GitHub OIDC, ...).
+  #
+  # Resolution chain when empty (highest priority first):
   #   1. https://<grafana.ingress.hosts[0].host>  when chart manages Grafana's ingress
   #   2. https://<hub.ingress.api.host>           when chart manages Hub's ingress
   #   3. hub.webhookURL                           BYO fallback

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -25,16 +25,25 @@ serviceAccount:
   name: ""
 
 hub:
-  # External URL where the hub is reachable (e.g. https://cronos.demo.earthly.dev).
-  # Used by the hub for webhook callbacks and by Grafana for dashboard log links.
-  publicBaseURL: ""
+  # External URL where GitHub posts webhooks. Hub registers
+  # <webhookURL>/webhooks/github with the GitHub App at boot.
+  #
+  # Defaults to "https://<hub.ingress.webhooks.host>" when ingress.enabled
+  # is true — most installs leave this empty and let the chart derive it.
+  # Set explicitly when:
+  #   - hub.ingress.enabled is false (BYO ingress / LoadBalancer / mesh),
+  #   - you need a non-default scheme (http for dev), port, or path prefix.
+  #
+  # When set explicitly AND hub.ingress.enabled is true, the host portion
+  # must equal hub.ingress.webhooks.host.
+  webhookURL: ""
 
   # URL the hub uses to build [More Details] links in PR comments back to
-  # the Grafana dashboard. Defaults to publicBaseURL when empty — that's
-  # the right answer for single-hostname installs (Caddy / content-type
+  # the Grafana dashboard. Defaults to webhookURL (derived or explicit) when
+  # empty — that's the right answer for single-hostname installs where
+  # Grafana is path-routed under the same host (Caddy / content-type
   # routing). Override only when Grafana is served from a separate
-  # hostname (e.g. grafana.lunar.example.com behind a distinct NGINX
-  # ingress, which is the topology the chart's docs advocate).
+  # hostname (e.g. grafana.lunar.example.com behind its own ingress).
   grafanaURLBase: ""
 
   rootDir: /hub/
@@ -176,25 +185,58 @@ hub:
       server: 8000
       http: 8001
 
-  # The hub serves gRPC (port 8000, used by CLI / CI agents / operator) and
-  # HTTP (port 8001, GitHub webhooks + log redirects) on separate ports.
-  # Most ingress controllers apply backend-protocol annotations per-Ingress,
-  # not per-path, so when enabled the chart renders two Ingress resources
-  # sharing the same host and TLS config (same pattern as Argo CD's chart).
+  # Hub has two trust boundaries:
+  #   1. Trusted API clients — lunar CLI, CI agents, operator. Talk to hub
+  #      over gRPC (port 8000) and HTTP (port 8001, /logs only). Both use
+  #      the same Hub auth token.
+  #   2. GitHub webhooks — public internet. POST to /webhooks/github only.
+  #
+  # The chart renders separate ingresses for each so you can put the API
+  # ingress on a private hostname (Tailscale, internal-DNS, VPN) and only
+  # expose the webhooks ingress to the public internet.
+  #
   # Disable entirely if you front the hub with a LoadBalancer Service, a
-  # service mesh, or some other ingress mechanism.
+  # service mesh, or your own Ingress YAML.
   ingress:
     enabled: false
-    host: ""
+
+    # Shared defaults. Applied to all three rendered Ingress resources
+    # unless overridden inside api.* / webhooks.* below.
     className: ""
     tls: []
-    # Annotations applied to both ingresses.
     annotations: {}
-    # Annotations applied only to the gRPC ingress. Required for most NGINX
-    # setups: nginx.ingress.kubernetes.io/backend-protocol: "GRPC".
-    grpcAnnotations: {}
-    # Annotations applied only to the HTTP ingress.
-    httpAnnotations: {}
+
+    # API ingress: gRPC + /logs. Used by lunar CLI, CI agents, and the
+    # operator. Renders TWO Ingress resources (api-grpc + api-http) sharing
+    # one hostname — the split exists because most ingress controllers
+    # apply backend-protocol annotations per-Ingress, not per-path. Safe
+    # to put on a private hostname.
+    api:
+      # Required when ingress.enabled is true.
+      host: ""
+
+      # Optional per-ingress overrides of the shared defaults above.
+      className: ""    # empty -> falls back to ingress.className
+      tls: []          # empty -> falls back to ingress.tls
+      annotations: {}  # merged on top of ingress.annotations
+
+      # Per-sub-Ingress annotations within the api block. NGINX users
+      # almost always need backend-protocol: "GRPC" for the gRPC half.
+      grpcAnnotations:
+        nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      httpAnnotations: {}
+
+    # Webhooks ingress: GitHub webhook receiver only. Public-facing.
+    # Lock this down to /webhooks if you want — nothing else lives here.
+    # Also the source of truth for the derived hub.webhookURL.
+    webhooks:
+      # Required when ingress.enabled is true.
+      host: ""
+
+      # Optional per-ingress overrides.
+      className: ""
+      tls: []
+      annotations: {}
 
   readinessProbe:
     enabled: true

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -45,22 +45,6 @@ hub:
   # GitHub would POST into the void.
   webhookURL: ""
 
-  # Base URL where Grafana is reachable. Used for two distinct purposes:
-  #   - HUB_GRAFANA_URL_BASE — base for hub's [More Details] links in PR comments
-  #   - GF_SERVER_ROOT_URL — Grafana's own self-knowledge (drives absolute
-  #     link generation, OIDC redirect_uri, etc). Critical to get right when
-  #     Grafana fronts third-party auth (Google, Okta, GitHub OIDC, ...).
-  #
-  # Defaults to https://<grafana.ingress.hosts[0].host> when chart-managed
-  # Grafana ingress is enabled — most installs just turn that on and leave
-  # this empty. Empty otherwise — the chart deliberately does NOT guess at
-  # a Grafana URL when it doesn't control the routing (no fallback to
-  # webhookURL or api.host — wrong trust boundary, wrong host).
-  #
-  # Set explicitly when Grafana is reachable via external routing the chart
-  # doesn't manage. Required for OIDC to work in that topology.
-  grafanaURLBase: ""
-
   rootDir: /hub/
 
   # Hub licence JWT secret mount. This token is authoritative for tenant and
@@ -226,22 +210,34 @@ hub:
     # one hostname — the split exists because most ingress controllers
     # apply backend-protocol annotations per-Ingress, not per-path. Safe
     # to put on a private hostname.
+    #
+    # Annotation API: webhooks.annotations is a single map (one Ingress);
+    # api has split grpcAnnotations + httpAnnotations because the two API
+    # Ingresses typically need different controller hints. There's no
+    # api.annotations layer — annotations that apply to both api Ingresses
+    # but not webhooks go in BOTH maps below (slight duplication, simpler
+    # contract). Annotations that apply to ALL three Ingresses go in the
+    # shared ingress.annotations above.
     api:
       # Required when ingress.enabled is true.
       host: ""
 
-      # Optional per-ingress overrides of the shared defaults above.
-      # Empty values fall back to ingress.className / ingress.tls.
+      # Optional per-ingress overrides of the shared defaults above. Note
+      # the asymmetry: per-block tls/className are matched against the
+      # shared defaults via Helm's `default` — empty list/string falls
+      # back to shared, so there's no way to say "I want NO TLS on this
+      # block when shared TLS is set." If you need per-block TLS, set it
+      # only on the block(s) that should have it (leave others as []).
       className: ""
       tls: []
 
       # Per-sub-Ingress annotations, layered on top of ingress.annotations.
-      # NGINX users almost always need backend-protocol: "GRPC" for the gRPC
-      # half. To add the same annotation to BOTH api Ingresses, either put it
-      # in ingress.annotations (shared with webhooks too) or duplicate it under
-      # both maps below.
-      grpcAnnotations:
-        nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      # NGINX users need backend-protocol: "GRPC" for the gRPC half; other
+      # controllers have their own equivalent (ALB: backend-protocol-version:
+      # GRPC; Traefik: scheme h2c per-service; etc). Chart ships {} as
+      # default to stay controller-neutral — set the appropriate value for
+      # your ingress class. See README "Ingress" for examples.
+      grpcAnnotations: {}
       httpAnnotations: {}
 
     # Webhooks ingress: GitHub webhook receiver only. Public-facing.
@@ -251,7 +247,8 @@ hub:
       # Required when ingress.enabled is true.
       host: ""
 
-      # Optional per-ingress overrides.
+      # Optional per-ingress overrides. Same fall-back-to-shared
+      # behavior as api.* above.
       className: ""
       tls: []
       annotations: {}
@@ -371,6 +368,25 @@ operator:
 
 grafana:
   enabled: true
+
+  # External URL where Grafana is reachable. Used for two distinct purposes:
+  #   - GF_SERVER_ROOT_URL — Grafana's own self-knowledge (drives absolute
+  #     link generation, OIDC redirect_uri, etc). Critical to get right when
+  #     Grafana fronts third-party auth (Google, Okta, GitHub OIDC, ...).
+  #   - HUB_GRAFANA_URL_BASE — base for hub's [More Details] links in PR
+  #     comments. The hub consumes this; it doesn't own it.
+  #
+  # Defaults to https://<grafana.ingress.hosts[0].host> when chart-managed
+  # Grafana ingress is enabled — most installs just turn that on and leave
+  # this empty. Empty otherwise — the chart deliberately does NOT guess at
+  # a Grafana URL when it doesn't control the routing (no fallback to
+  # hub.webhookURL or api.host — wrong trust boundary, wrong host).
+  #
+  # Set explicitly when Grafana is reachable via external routing the chart
+  # doesn't manage (Caddy / mesh / shared LB with path routing). Required
+  # for OIDC to work in that topology. The chart fails fast at install time
+  # if grafana.enabled is true and no URL can be determined.
+  externalURL: ""
 
   # Admin credentials. Leave secretName empty to have the chart generate them
   # (recommended for fresh installs): username defaults to "admin", password

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -38,12 +38,17 @@ hub:
   # must equal hub.ingress.webhooks.host.
   webhookURL: ""
 
-  # URL the hub uses to build [More Details] links in PR comments back to
-  # the Grafana dashboard. Defaults to webhookURL (derived or explicit) when
-  # empty — that's the right answer for single-hostname installs where
-  # Grafana is path-routed under the same host (Caddy / content-type
-  # routing). Override only when Grafana is served from a separate
-  # hostname (e.g. grafana.lunar.example.com behind its own ingress).
+  # Base URL the hub uses for [More Details] links in PR comments. Resolution
+  # chain when empty (highest priority first):
+  #   1. https://<grafana.ingress.hosts[0].host>  when chart manages Grafana's ingress
+  #   2. https://<hub.ingress.api.host>           when chart manages Hub's ingress
+  #   3. hub.webhookURL                           BYO fallback
+  #
+  # The api.host fallback is deliberate: Grafana is a human-facing dashboard
+  # accessed from internal browsers — same trust boundary as lunar CLI / CI
+  # agent traffic, NOT the public webhooks ingress. Set explicitly when
+  # Grafana lives on a hostname none of these capture (separate ingress that
+  # isn't chart-managed, external Grafana, etc).
   grafanaURLBase: ""
 
   rootDir: /hub/


### PR DESCRIPTION
## Summary

Splits hub's single ingress into two logical config blocks — `hub.ingress.api` (CLI / CI agents / operator: gRPC + `/logs`) and `hub.ingress.webhooks` (GitHub webhook receiver) — so customers can put the webhook ingress on a public hostname and keep API traffic on a private one. Customer ask: *"It'd be nice if the helm chart supported dual ingresses. We want to run the webhook listener on a different host and limit it to the webhook paths."*

Also surfaces and fixes a latent issue: `/logs` was grouped with webhooks but is actually authenticated API traffic, not public webhook traffic. Moving it to the api block restores the real trust boundary.

Renames `hub.publicBaseURL` -> `hub.webhookURL` (now auto-derived from `hub.ingress.webhooks.host` for chart-managed installs — single source of truth, no drift possible).

## What renders

Three `Ingress` resources from two logical blocks:

| Resource | Host | Path | Backend |
|---|---|---|---|
| `<release>-hub-api-grpc` | `api.host` | `/` | hub gRPC (8000) |
| `<release>-hub-api-http` | `api.host` | `/logs` | hub HTTP (8001) |
| `<release>-hub-webhooks` | `webhooks.host` | `/webhooks` | hub HTTP (8001) |

`api-grpc` and `api-http` split exists because most ingress controllers apply `backend-protocol` per-Ingress, not per-path. Same pattern as Argo CD's chart.

## Breaking changes (2.0.0)

Strict semver — `hub.ingress` shape changed and `hub.publicBaseURL` renamed. The chart fails fast at install time on 1.x values with a migration message pointing to the new README section. Migration is a mechanical YAML rewrite (~5 minutes), shown in `README.md > Migrating from chart 1.x`.

## Files

- `charts/lunar/Chart.yaml` — 1.0.2 -> 2.0.0
- `charts/lunar/values.yaml` — `hub.ingress` restructure, `publicBaseURL` -> `webhookURL`
- `charts/lunar/templates/_helpers.tpl` — `lunar.webhookURL`, `lunar.validateIngress`, `lunar.rejectLegacyIngressShape`, `lunar.ingress.{className,tls,annotations}`
- `charts/lunar/templates/hub-ingress.yaml` — rewritten for 3 Ingress resources
- `charts/lunar/templates/hub-deployment.yaml` — consumes derived `webhookURL` via helper
- `README.md` — Ingress section rewrite, migration section, values table updates, "Why webhookURL must match webhooks.host" explainer with mermaid sequence diagram