### PR TITLE
hub: optional startupProbe for slow-startup migration windows

### DIFF
--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,6 +9,19 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
+## [Unreleased]
+
+### Added
+
+- **Optional `hub.startupProbe`.** New optional probe (disabled by default
+  to preserve current behaviour) that gives Hub a longer window to come
+  Ready before liveness/readiness kick in. Useful when Hub takes longer
+  than `livenessProbe.failureThreshold × periodSeconds` to start — e.g.
+  on a cold start with a substantial Postgres schema migration.
+  Default tuning when enabled: `30 × 5s = 150s` startup window. Set
+  `hub.startupProbe.enabled: true` and tune `failureThreshold` /
+  `periodSeconds` to taste.
+
 ## [2.0.0] - 2026-05-20
 
 ### Breaking

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -183,6 +183,17 @@ spec:
             failureThreshold: {{ .failureThreshold }}
           {{- end }}
           {{- end }}
+          {{- if .Values.hub.startupProbe.enabled }}
+          {{- with .Values.hub.startupProbe }}
+          startupProbe:
+            httpGet:
+              path: /health
+              port: hub-health
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
+          {{- end }}
+          {{- end }}
           ports:
             - name: hub-grpc
               containerPort: 8000

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -265,6 +265,22 @@ hub:
     periodSeconds: 5
     failureThreshold: 3
 
+  # Optional startup probe (disabled by default to preserve existing
+  # behaviour). Enable when Hub takes longer to become Ready than the
+  # liveness probe's failureThreshold × periodSeconds tolerates — e.g.
+  # on a cold start with a substantial Postgres schema migration. While
+  # the startupProbe is running, kubelet suppresses liveness/readiness
+  # probe failures, so Hub gets `failureThreshold × periodSeconds`
+  # seconds total before kubelet starts considering it unhealthy.
+  #
+  # Default tuning when enabled is 30 × 5s = 150s. Raise
+  # `failureThreshold` for larger databases with longer migrations.
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 0
+    periodSeconds: 5
+    failureThreshold: 30
+
   labels: {}
   annotations: {}
   podAnnotations: {}


### PR DESCRIPTION
## Summary

Adds an **optional** `hub.startupProbe` (disabled by default to preserve existing behaviour). When enabled, kubelet gives Hub the full `failureThreshold × periodSeconds` window to become Ready before liveness/readiness probes start counting failures.

Default tuning when enabled: `30 × 5s = 150s` startup window.

## Why

On 2026-05-26 the `earthly-internal` dogfood cluster was rolled from Hub `2.0.0` → `e845ff9d`. The new Hub takes **~52s** to become Ready (Postgres schema migration v175 → v182 + the new `sqlapi_user` role creation). The existing chart probes are configured with `initialDelaySeconds=0, periodSeconds=5, failureThreshold=3` — a 15s tolerance window — so kubelet killed the pod mid-migration in a crashloop.

The workaround was an out-of-band `kubectl patch deploy/lunar-hub` adding a startupProbe imperatively. That's incompatible with a future `helm upgrade` (would wipe the patch).

## Behaviour

| Mode | Rendered |
|---|---|
| `hub.startupProbe.enabled: false` (default) | nothing — same as today |
| `hub.startupProbe.enabled: true` | full `startupProbe:` block with `/health` HTTP probe |

While the startupProbe is running, kubelet suppresses liveness/readiness probe failures. Once the startupProbe succeeds for the first time, control hands back to liveness/readiness for ongoing health checks (no double-coverage).

## Test plan

- [x] `helm template` with `hub.startupProbe.enabled=true` renders the full block (verified locally)
- [x] `helm template` with default values renders **zero** `startupProbe:` references (verified locally — `grep -c startupProbe` returns 0)
- [ ] Apply to the `earthly-internal` cluster (replaces the kubectl-patched stopgap with chart-managed config) once this lands and the chart version bumps

## Notes

- No version bump in this PR — held for the next release cut. Chart 2.0.0 release happened May 20; the next minor would carry this (and other recent additions).
- Mirrors the existing `hub.livenessProbe` / `hub.readinessProbe` shape exactly for consistency.

---
*This PR was drafted by AI.*