### PR TITLE
chart: move static Grafana env defaults into the lunar-grafana image

### DIFF
--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,6 +9,19 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
+## [Unreleased]
+
+### Changed
+
+- Grafana: moved the static, image-coupled `GF_*` settings out of the
+  Grafana Deployment `env` and into the `lunar-grafana` image
+  (`GF_INSTALL_PLUGINS`, `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS`,
+  `GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH`, `GF_USERS_ALLOW_SIGN_UP`,
+  `GF_USERS_DEFAULT_THEME`, `GF_FEATURE_TOGGLES_ENABLE`). They now version
+  with the image and no longer shadow it; override per-deployment via
+  `grafana.extraEnv`. Requires a `lunar-grafana` image with these baked in
+  (built from the matching `grafana/Earthfile`).
+
 ## [2.3.0] - 2026-06-05
 
 ### Added

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: "A Helm chart for Earthly Lunar 🌙"
 type: application
-version: 2.4.0
+version: 2.3.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: "A Helm chart for Earthly Lunar 🌙"
 type: application
-version: 2.3.0
+version: 2.4.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/grafana-deployment.yaml
+++ b/charts/lunar/templates/grafana-deployment.yaml
@@ -83,18 +83,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "lunar.grafanaAdminSecretName" $ }}
                   key: {{ .admin.passwordKey }}
-            - name: GF_INSTALL_PLUGINS
-              value: "yesoreyeram-infinity-datasource,marcusolsson-dynamictext-panel,volkovlabs-echarts-panel"
-            - name: GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS
-              value: "earthly-json-tree-panel,earthly-text-diff-panel"
-            - name: GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
-              value: "/etc/grafana/provisioning/dashboards/home.json"
-            - name: GF_USERS_ALLOW_SIGN_UP
-              value: "false"
-            - name: GF_USERS_DEFAULT_THEME
-              value: "tron"
-            - name: GF_FEATURE_TOGGLES_ENABLE
-              value: "grafanaconThemes"
+            # GF_INSTALL_PLUGINS, GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS,
+            # GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH, GF_USERS_ALLOW_SIGN_UP,
+            # GF_USERS_DEFAULT_THEME and GF_FEATURE_TOGGLES_ENABLE are baked into
+            # the lunar-grafana image now (they're coupled to the plugins,
+            # dashboards and theme it bundles); override via grafana.extraEnv.
             {{- with .extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
## Summary
- Remove six static, image-coupled Grafana env vars from the Deployment template so they version with the `lunar-grafana` image instead of being shadowed by the chart.
- Removed: `GF_INSTALL_PLUGINS`, `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS`, `GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH`, `GF_USERS_ALLOW_SIGN_UP`, `GF_USERS_DEFAULT_THEME`, `GF_FEATURE_TOGGLES_ENABLE`.
- Content-only: **no `Chart.yaml` version bump** (the release pipeline owns versioning). Documented under `## [Unreleased]`.

## Why
A container `env` entry overrides the image `ENV` of the same name, so these chart literals shadowed the image. After the grafana image renamed its panel plugins to `earthly-jsontree-panel` / `earthly-textdiff-panel`, the chart's stale `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS` kept allowing the old IDs, so the unsigned panels stopped loading. Keeping these defaults in the image keeps the allow-list, installed plugins, home dashboard and theme in lockstep with the bundled content; per-deployment overrides remain available via `grafana.extraEnv`.

## Versioning / release coordination
No version bump here — `release-charts` -> `bump-and-pr.yml` assigns the chart version and image tags at release time (a manual bump would also collide with the in-flight **Release 2.3.1** #56 and the draft **chart 2.4.0** #54).

:warning: This must land **before/with** the release that ships the matching grafana image. `lunar-grafana` is built by `+ci-images-hub` at the release version, and `lunar-grafana:2.3.1` carries these baked-in ENVs. If **Release 2.3.1** (#56) merges without this PR, chart 2.3.1 would point at `lunar-grafana:2.3.1` (new plugin IDs) while still hardcoding the old IDs -> broken panels. Recommended order: merge this PR to `main` first, then merge #56.

## Test plan
- [x] `helm lint charts/lunar`
- [x] `helm template` renders the grafana deployment with the vars removed and `grafana.extraEnv` still appended
- [ ] Deploy chart with `lunar-grafana:2.3.1` and confirm panels load + theme/home dashboard apply