### PR TITLE
chart: file the grafana env changelog entry under [2.3.1]

### DIFF
--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,7 +9,7 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
-## [Unreleased]
+## [2.3.1] - 2026-06-17
 
 ### Changed
 


### PR DESCRIPTION
## Summary
Relabel the Grafana env-move changelog entry from `## [Unreleased]` to `## [2.3.1] - 2026-06-17`.

That change (#55) shipped in the **2.3.1** release (#56), but the auto-generated Release PR doesn't touch `CHANGELOG.md`, so the entry was left under `[Unreleased]` and there was no `## [2.3.1]` section.

Docs-only — no template, values, or version changes.

Made with [Cursor](https://cursor.com)