### PR TITLE
[ENG-1037] chart: run hub migrations in a pre-rollout Job

### DIFF
--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -21,6 +21,10 @@ history see `git log -- charts/lunar/`.
   scaled-up/restarted pods safe (they don't run the Job). This replaces the
   per-pod init-container approach and is a prerequisite for running the hub as
   multiple replicas.
+- Bump the hub, snippet operator/init/sidecar, and grafana image tags
+  `2.4.1 → 2.5.0` so a default install of this chart pulls a hub image that
+  ships `/bin/lunar-hub-migrate`. **Publish this chart version only once the
+  2.5.0 images exist** (released from lunar).
 
 ### Requires
 

--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,6 +9,23 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
+## [2.5.0] - 2026-06-26
+
+### Changed
+
+- **Migrations now run in an init container**, not at hub boot. A `migrate`
+  init container runs `/bin/lunar-hub-migrate` before the hub server starts,
+  so a hub pod never serves an un-migrated schema. When several hub pods start
+  together, the migration advisory lock ensures one migrates and the rest wait
+  — a prerequisite for running the hub as multiple replicas.
+
+### Requires
+
+- A hub image that ships `/bin/lunar-hub-migrate` and **no longer migrates at
+  boot** (lunar ≥ the build that removes boot migration). Older hub images are
+  incompatible with this chart version (the init container's binary is absent,
+  and a matching hub image won't self-migrate).
+
 ## [2.4.1] - 2026-06-24
 
 ### Changed

--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -13,18 +13,22 @@ history see `git log -- charts/lunar/`.
 
 ### Changed
 
-- **Migrations now run in an init container**, not at hub boot. A `migrate`
-  init container runs `/bin/lunar-hub-migrate` before the hub server starts,
-  so a hub pod never serves an un-migrated schema. When several hub pods start
-  together, the migration advisory lock ensures one migrates and the rest wait
-  — a prerequisite for running the hub as multiple replicas.
+- **Migrations now run as a pre-rollout hook Job**, not at hub boot. A
+  `hub-migrate` Job runs `/bin/lunar-hub-migrate` once per release via a Helm
+  `pre-install`/`pre-upgrade` hook — before the hub Deployment is updated — so
+  migrations complete and gate the rollout. The hub server asserts the schema
+  is current at boot and refuses to start if it's behind, which also makes
+  scaled-up/restarted pods safe (they don't run the Job). This replaces the
+  per-pod init-container approach and is a prerequisite for running the hub as
+  multiple replicas.
 
 ### Requires
 
-- A hub image that ships `/bin/lunar-hub-migrate` and **no longer migrates at
-  boot** (lunar ≥ the build that removes boot migration). Older hub images are
-  incompatible with this chart version (the init container's binary is absent,
-  and a matching hub image won't self-migrate).
+- A hub image that ships `/bin/lunar-hub-migrate`, **no longer migrates at
+  boot**, and **asserts the schema at boot** (lunar ≥ the build that removes
+  boot migration and adds the schema assertion). Older hub images are
+  incompatible with this chart version (the migrate binary is absent, and a
+  matching hub image won't self-migrate).
 
 ## [2.4.1] - 2026-06-24
 

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: "A Helm chart for Earthly Lunar \U0001F319"
 type: application
-version: 2.4.1
+version: 2.5.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -43,6 +43,45 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+        # Apply DB migrations before the hub server starts. The hub no longer
+        # migrates at boot, so this gates startup — the server never serves an
+        # un-migrated schema. The migration advisory lock means that when
+        # several hub pods start together, one migrates and the rest wait.
+        # Requires a hub image that ships /bin/lunar-hub-migrate.
+        - name: migrate
+          {{- with .Values.hub.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.hub.image.repository }}:{{ .Values.hub.image.tag }}"
+          imagePullPolicy: {{ .Values.hub.image.pullPolicy }}
+          command: ["/bin/lunar-hub-migrate"]
+          {{- with .Values.hub }}
+          env:
+            - name: HUB_DB_NAME
+              value: {{ .db.name | quote }}
+            - name: HUB_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .db.user.secretName }}
+                  key: {{ .db.user.secretKey }}
+            - name: HUB_DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .db.pass.secretName }}
+                  key: {{ .db.pass.secretKey }}
+            - name: HUB_DB_HOST
+              value: {{ .db.host | quote }}
+            - name: HUB_DB_PORT
+              value: {{ .db.port | quote }}
+            - name: HUB_DB_WAIT_SECS
+              value: {{ .db.waitSecs | quote }}
+            - name: HUB_DB_CONNECTION_OPTIONS
+              value: {{ .db.connectionOptions | quote }}
+            - name: HUB_DB_MIGRATIONS_PATH
+              value: "/usr/share/migrations"
+          {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.hub.securityContext }}

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -43,45 +43,9 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        # Apply DB migrations before the hub server starts. The hub no longer
-        # migrates at boot, so this gates startup — the server never serves an
-        # un-migrated schema. The migration advisory lock means that when
-        # several hub pods start together, one migrates and the rest wait.
-        # Requires a hub image that ships /bin/lunar-hub-migrate.
-        - name: migrate
-          {{- with .Values.hub.securityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          image: "{{ .Values.hub.image.repository }}:{{ .Values.hub.image.tag }}"
-          imagePullPolicy: {{ .Values.hub.image.pullPolicy }}
-          command: ["/bin/lunar-hub-migrate"]
-          {{- with .Values.hub }}
-          env:
-            - name: HUB_DB_NAME
-              value: {{ .db.name | quote }}
-            - name: HUB_DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .db.user.secretName }}
-                  key: {{ .db.user.secretKey }}
-            - name: HUB_DB_PASS
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .db.pass.secretName }}
-                  key: {{ .db.pass.secretKey }}
-            - name: HUB_DB_HOST
-              value: {{ .db.host | quote }}
-            - name: HUB_DB_PORT
-              value: {{ .db.port | quote }}
-            - name: HUB_DB_WAIT_SECS
-              value: {{ .db.waitSecs | quote }}
-            - name: HUB_DB_CONNECTION_OPTIONS
-              value: {{ .db.connectionOptions | quote }}
-            - name: HUB_DB_MIGRATIONS_PATH
-              value: "/usr/share/migrations"
-          {{- end }}
+      # DB migrations run once per release as a pre-rollout hook Job
+      # (hub-migrate-job.yaml), not here — the hub server asserts the schema is
+      # current at boot and refuses to start if it's behind.
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.hub.securityContext }}

--- a/charts/lunar/templates/hub-migrate-job.yaml
+++ b/charts/lunar/templates/hub-migrate-job.yaml
@@ -73,4 +73,21 @@ spec:
               value: {{ .db.connectionOptions | quote }}
             - name: HUB_DB_MIGRATIONS_PATH
               value: "/usr/share/migrations"
+            # Licence carries the Elastic telemetry creds; with it, migration
+            # logs ship to the same tenant-tagged Elastic stream as the hub.
+            # Best-effort in the binary — falls back to stderr if absent.
+            - name: HUB_LICENCE_FILE
+              value: {{ .licence.filePath | quote }}
           {{- end }}
+          volumeMounts:
+            - name: hub-licence
+              mountPath: {{ .Values.hub.licence.filePath | quote }}
+              subPath: {{ base .Values.hub.licence.filePath | quote }}
+              readOnly: true
+      volumes:
+        - name: hub-licence
+          secret:
+            secretName: {{ .Values.hub.licence.secretName }}
+            items:
+              - key: {{ .Values.hub.licence.secretKey }}
+                path: {{ base .Values.hub.licence.filePath | quote }}

--- a/charts/lunar/templates/hub-migrate-job.yaml
+++ b/charts/lunar/templates/hub-migrate-job.yaml
@@ -40,6 +40,22 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      # Mirror the hub pod's scheduling so the migrate Job lands on the same
+      # nodes — otherwise a hub pinned to a tainted/dedicated node group gets an
+      # unschedulable migrate pod that burns activeDeadlineSeconds and fails the
+      # pre-rollout hook.
+      {{- with .Values.hub.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hub.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hub.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: migrate
           {{- with .Values.hub.securityContext }}

--- a/charts/lunar/templates/hub-migrate-job.yaml
+++ b/charts/lunar/templates/hub-migrate-job.yaml
@@ -1,0 +1,76 @@
+{{- /*
+Database migration Job. Runs once per release via a Helm pre-install/pre-upgrade
+hook — before the hub Deployment is created or updated — so migrations complete
+and gate the rollout (no new hub pod serves an un-migrated schema). The hub
+server no longer migrates at boot; it asserts the schema is current and refuses
+to start if behind, which also covers scaled-up/restarted pods (they don't run
+this Job).
+
+hook-weight -5 runs it early; hook-delete-policy keeps a failed Job around for
+debugging (before-hook-creation cleans up the previous one on the next run).
+Requires a hub image that ships /bin/lunar-hub-migrate.
+*/}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "lunar.fullname" . }}-hub-migrate
+  labels:
+    {{- include "lunar.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hub-migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 600
+  template:
+    metadata:
+      labels:
+        {{- include "lunar.labels" . | nindent 8 }}
+        app.kubernetes.io/component: hub-migrate
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "lunar.serviceAccountName" . }}
+      {{- with .Values.hub.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: migrate
+          {{- with .Values.hub.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.hub.image.repository }}:{{ .Values.hub.image.tag }}"
+          imagePullPolicy: {{ .Values.hub.image.pullPolicy }}
+          command: ["/bin/lunar-hub-migrate"]
+          {{- with .Values.hub }}
+          env:
+            - name: HUB_DB_NAME
+              value: {{ .db.name | quote }}
+            - name: HUB_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .db.user.secretName }}
+                  key: {{ .db.user.secretKey }}
+            - name: HUB_DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .db.pass.secretName }}
+                  key: {{ .db.pass.secretKey }}
+            - name: HUB_DB_HOST
+              value: {{ .db.host | quote }}
+            - name: HUB_DB_PORT
+              value: {{ .db.port | quote }}
+            - name: HUB_DB_WAIT_SECS
+              value: {{ .db.waitSecs | quote }}
+            - name: HUB_DB_CONNECTION_OPTIONS
+              value: {{ .db.connectionOptions | quote }}
+            - name: HUB_DB_MIGRATIONS_PATH
+              value: "/usr/share/migrations"
+          {{- end }}

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -233,7 +233,7 @@ hub:
   image:
     repository: "ghcr.io/earthly/lunar-hub"
     pullPolicy: IfNotPresent
-    tag: "2.4.1"
+    tag: "2.5.0"
   service:
     type: ClusterIP
     ports:
@@ -327,15 +327,15 @@ operator:
   image:
     repository: "ghcr.io/earthly/lunar-snippet-operator"
     pullPolicy: IfNotPresent
-    tag: "2.4.1"
+    tag: "2.5.0"
   initImage:
     repository: "ghcr.io/earthly/lunar-snippet-init"
     pullPolicy: IfNotPresent
-    tag: "2.4.1"
+    tag: "2.5.0"
   sidecarImage:
     repository: "ghcr.io/earthly/lunar-snippet-sidecar"
     pullPolicy: IfNotPresent
-    tag: "2.4.1"
+    tag: "2.5.0"
   # Namespace where script pods are created. Defaults to the release namespace.
   # If set, the namespace must already exist — the chart will not create it.
   scriptNamespace: ""
@@ -443,7 +443,7 @@ grafana:
   image:
     repository: "ghcr.io/earthly/lunar-grafana"
     pullPolicy: IfNotPresent
-    tag: "2.4.1"
+    tag: "2.5.0"
   service:
     type: ClusterIP
     port: 80


### PR DESCRIPTION
## Summary
Adds a `migrate` init container to the hub Deployment that runs `/bin/lunar-hub-migrate` before the hub server starts. The hub no longer migrates at boot, so this gates startup — a pod never serves an un-migrated schema. When several hub pods start together, the migration **advisory lock** ensures one migrates and the rest wait (prerequisite for multi-replica hub).

## Context
Part of the Hub HA work (R6). Pairs with the lunar change that removes boot-time migration and ships the binary: **earthly/lunar#1968** (ENG-1036).

## Details
- Init container reuses the hub's **DB env** only (least-privilege; the migrator loads a minimal DB + SQL-API config, no GitHub App creds / licence).
- Chart bumped **2.4.1 → 2.5.0**; CHANGELOG updated.

## ⚠️ Compatibility / rollout
- **Requires a hub image shipping `/bin/lunar-hub-migrate` that no longer self-migrates** (lunar#1968). Older hub images are incompatible with this chart version.
- Consumers must deploy this chart **together with** the new hub image.
- **localdev/e2e** currently pin `--version 0.8.0` from the published repo; they need re-pinning to 2.5.0 (or `LUNAR_CHART_PATH` for local) once this is released — tracked under ENG-1037.