### PR TITLE
[ENG-1038] chart: multi-replica baseline for the hub (replicaCount, PDB, spread, grace)

### DIFF
--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,6 +9,21 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
+## [2.6.0] - 2026-06-29
+
+### Added
+
+- **Multi-replica baseline for the hub.** New `hub.replicaCount` (default `1`,
+  unchanged behavior), `hub.terminationGracePeriodSeconds` (default `60`),
+  `hub.topologySpreadConstraints` (default none), and an optional
+  `hub.podDisruptionBudget` (default **off** — a PDB on a single replica can
+  block voluntary node drains; enable for HA). These let the hub run at
+  `replicaCount > 1` healthily (spread across nodes/zones, drain-safe). HA also
+  requires `hub.persistence.enabled=false` (hub state lives in Postgres).
+
+> Note: sequences after 2.5.0 (the migrate pre-rollout Job, #64). If 2.5.0 has
+> not landed when this merges, reconcile the version.
+
 ## [2.4.1] - 2026-06-24
 
 ### Changed

--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -19,7 +19,9 @@ history see `git log -- charts/lunar/`.
   `hub.podDisruptionBudget` (default **off** — a PDB on a single replica can
   block voluntary node drains; enable for HA). These let the hub run at
   `replicaCount > 1` healthily (spread across nodes/zones, drain-safe). HA also
-  requires `hub.persistence.enabled=false` (hub state lives in Postgres).
+  requires `hub.persistence.enabled=false` (hub state lives in Postgres) — the
+  chart now **fails fast at render time** on `replicaCount > 1` with persistence
+  still enabled, instead of leaving replicas stuck contending for one RWO PVC.
 
 > Note: sequences after 2.5.0 (the migrate pre-rollout Job, #64). If 2.5.0 has
 > not landed when this merges, reconcile the version.

--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -22,6 +22,11 @@ history see `git log -- charts/lunar/`.
   requires `hub.persistence.enabled=false` (hub state lives in Postgres) — the
   chart now **fails fast at render time** on `replicaCount > 1` with persistence
   still enabled, instead of leaving replicas stuck contending for one RWO PVC.
+  A **soft node-spread is applied by default** (maxSkew 1 across
+  `kubernetes.io/hostname`, `ScheduleAnyway`) so multi-replica deploys survive a
+  node loss without extra config; override via `hub.topologySpreadConstraints`.
+  The chart also **fails fast if the PDB sets both `minAvailable` and
+  `maxUnavailable`** (the API server rejects that).
 
 > Note: version sequences after 2.10.0 — reconcile if another chart PR lands a
 > 2.11.0 first. The emptyDir change (charts#68) supersedes the persistence

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: "A Helm chart for Earthly Lunar \U0001F319"
 type: application
-version: 2.4.1
+version: 2.6.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/_helpers.tpl
+++ b/charts/lunar/templates/_helpers.tpl
@@ -337,3 +337,15 @@ Usage:
 {{- toYaml $merged -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Fail fast on multi-replica + local persistence: replicas can't share the RWO
+PVC, and the Recreate strategy persistence forces is incompatible with rolling
+more than one replica. HA keeps hub state in Postgres, so persistence must be
+off at replicaCount > 1.
+*/}}
+{{- define "lunar.validateHubReplicas" -}}
+{{- if and (gt (int (.Values.hub.replicaCount | default 1)) 1) .Values.hub.persistence.enabled -}}
+{{- fail "hub.replicaCount > 1 requires hub.persistence.enabled=false: replicas can't share the RWO PVC (and the Recreate strategy it forces is incompatible with rolling multiple replicas). HA keeps hub state in Postgres — see the HA operations runbook." -}}
+{{- end -}}
+{{- end -}}

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -11,8 +11,11 @@ metadata:
   labels:
     {{- include "lunar.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.hub.replicaCount | default 1 }}
   {{- if .Values.hub.persistence.enabled }}
+  # Recreate is required while the hub mounts a RWO PVC; note it is
+  # incompatible with replicaCount > 1 (HA runs with persistence disabled,
+  # hub state lives in Postgres).
   strategy:
     type: Recreate
   {{- end }}
@@ -38,7 +41,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "lunar.serviceAccountName" . }}
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: {{ .Values.hub.terminationGracePeriodSeconds | default 60 }}
       {{- with .Values.hub.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -270,5 +273,9 @@ spec:
       {{- end }}
       {{- with .Values.hub.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hub.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -2,6 +2,7 @@
 {{- include "lunar.hubLicenceCheck" . }}
 {{- include "lunar.rejectLegacyIngressShape" . }}
 {{- include "lunar.validateGrafana" . }}
+{{- include "lunar.validateHubReplicas" . }}
 {{- $webhookURL := include "lunar.webhookURL" . -}}
 {{- $grafanaURL := include "lunar.grafanaURL" . -}}
 apiVersion: apps/v1

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -296,4 +296,19 @@ spec:
       {{- with .Values.hub.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
+      {{- else }}
+      # Default: soft-spread hub replicas across nodes so a single node loss
+      # can't take down the whole hub — the PDB only guards *voluntary*
+      # disruptions (drains), not a node crash. ScheduleAnyway keeps small /
+      # single-node clusters schedulable (and is a no-op at replicaCount 1).
+      # Override hub.topologySpreadConstraints for a stricter spread (e.g. a
+      # hard zone spread with DoNotSchedule).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "lunar.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: hub
       {{- end }}

--- a/charts/lunar/templates/hub-pdb.yaml
+++ b/charts/lunar/templates/hub-pdb.yaml
@@ -4,6 +4,9 @@ block voluntary node drains. Enable it for multi-replica (HA) deploys so a node
 drain / rollout can't take down all hub replicas at once.
 */}}
 {{- if .Values.hub.podDisruptionBudget.enabled }}
+{{- if and .Values.hub.podDisruptionBudget.minAvailable .Values.hub.podDisruptionBudget.maxUnavailable }}
+{{- fail "hub.podDisruptionBudget: set only one of minAvailable / maxUnavailable, not both — a PDB with both is rejected by the API server. (The default sets maxUnavailable; comment it out if you set minAvailable.)" }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/lunar/templates/hub-pdb.yaml
+++ b/charts/lunar/templates/hub-pdb.yaml
@@ -1,0 +1,25 @@
+{{- /*
+PodDisruptionBudget for the hub. Off by default — a PDB on a single replica can
+block voluntary node drains. Enable it for multi-replica (HA) deploys so a node
+drain / rollout can't take down all hub replicas at once.
+*/}}
+{{- if .Values.hub.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "lunar.fullname" . }}-hub
+  labels:
+    {{- include "lunar.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hub
+spec:
+  {{- with .Values.hub.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.hub.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "lunar.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: hub
+{{- end }}

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -40,6 +40,27 @@ hub:
   # GitHub would POST into the void.
   webhookURL: ""
   rootDir: /hub/
+  # Number of hub replicas. Keep 1 unless running the hub in HA (multi-replica)
+  # mode — HA requires persistence disabled (hub state lives in Postgres). See
+  # the HA operations runbook.
+  replicaCount: 1
+  # Grace period for the hub to drain on SIGTERM; must be >= the hub's shutdown
+  # budget.
+  terminationGracePeriodSeconds: 60
+  # PodDisruptionBudget for the hub. Off by default — a PDB on a single replica
+  # can block voluntary node drains. Enable for multi-replica deploys. Set one
+  # of maxUnavailable / minAvailable, not both.
+  podDisruptionBudget:
+    enabled: false
+    maxUnavailable: 1
+    # minAvailable: 1
+  # Spread hub replicas across nodes/zones (multi-replica). Empty = no spread.
+  # e.g. - maxSkew: 1
+  #        topologyKey: kubernetes.io/hostname
+  #        whenUnsatisfiable: ScheduleAnyway
+  #        labelSelector:
+  #          matchLabels: { app.kubernetes.io/component: hub }
+  topologySpreadConstraints: []
   # Hub licence JWT secret mount. This token is authoritative for tenant and
   # telemetry routing configuration.
   licence:

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -48,18 +48,18 @@ hub:
   # budget.
   terminationGracePeriodSeconds: 60
   # PodDisruptionBudget for the hub. Off by default — a PDB on a single replica
-  # can block voluntary node drains. Enable for multi-replica deploys. Set one
-  # of maxUnavailable / minAvailable, not both.
+  # can block voluntary node drains. Enable for multi-replica deploys. Set
+  # exactly one of maxUnavailable / minAvailable — the chart fails fast at
+  # render time if both are set (the API server rejects a PDB with both).
   podDisruptionBudget:
     enabled: false
     maxUnavailable: 1
     # minAvailable: 1
-  # Spread hub replicas across nodes/zones (multi-replica). Empty = no spread.
-  # e.g. - maxSkew: 1
-  #        topologyKey: kubernetes.io/hostname
-  #        whenUnsatisfiable: ScheduleAnyway
-  #        labelSelector:
-  #          matchLabels: { app.kubernetes.io/component: hub }
+  # Extra pod topology-spread constraints for hub replicas. Empty is NOT
+  # "no spread" — the chart applies a soft default (maxSkew 1 across
+  # kubernetes.io/hostname, ScheduleAnyway) so multi-replica deploys survive a
+  # node loss out of the box. Set this to override with your own (e.g. a hard
+  # zone spread); it replaces the default wholesale.
   topologySpreadConstraints: []
   # Hub licence JWT secret mount. This token is authoritative for tenant and
   # telemetry routing configuration.


### PR DESCRIPTION
## Summary

Adds the chart knobs needed to run the hub at `replicaCount > 1` healthily — the multi-replica baseline for the Hub-HA work (ENG-1038). Everything is **non-destructive**: defaults preserve today's single-replica behavior.

## Changes

- **`hub.replicaCount`** (default `1`) — `replicas` was hardcoded.
- **`hub.terminationGracePeriodSeconds`** (default `60`) — was hardcoded; now configurable to size ≥ the hub's shutdown budget.
- **`hub.topologySpreadConstraints`** (default none) — spread replicas across nodes/zones.
- **`hub.podDisruptionBudget`** — new optional PDB template, **default off**. A PDB on a single replica can block voluntary node drains, so it's opt-in; enable for HA (`maxUnavailable: 1` by default).

## Notes

- Default `helm template` is byte-stable except the `replicas`/`grace` values now render from defaults (same numbers). PDB renders only when enabled.
- HA also requires `hub.persistence.enabled=false` (hub state lives in Postgres) — the `Recreate` strategy is incompatible with `replicaCount > 1`; noted inline.
- **Chart 2.6.0**, sequenced after 2.5.0 (the migrate pre-rollout Job, #64). If 2.5.0 hasn't landed when this merges, reconcile the version.
