### PR TITLE
[ENG-1033] chart: configurable, HA-right-sized DB connection budget

### DIFF
--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,6 +9,21 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
+## [2.9.0] - 2026-07-01
+
+### Added
+
+- **Configurable Postgres connection budget (R9).** New `hub.db.maxOpenConns`,
+  `hub.db.maxPoolConns`, and `hub.db.operatorPoolSize` render to
+  `HUB_DB_MAX_OPEN_CONNS` / `HUB_DB_MAX_POOL_CONNS` / `HUB_MAX_OPERATOR_POOL_SIZE`.
+  Defaults are the hub's existing values (`40 / 40 / 5`), so a single-replica
+  install is **unchanged** — no pool regression. The total Postgres connection
+  count is `replicaCount × (maxOpenConns + maxPoolConns + operatorPoolSize)`, so
+  **multi-replica deploys should lower `maxOpenConns`/`maxPoolConns`** to fit
+  `max_connections` (keep `maxPoolConns` ≥ peak concurrent River workers — the
+  sum of `hub.maxWorkers.*` — to avoid store-query serialization), and consider a
+  connection pooler for larger N. See the HA operations runbook.
+
 ## [2.8.1] - 2026-07-01
 
 ### Docs
@@ -98,6 +113,7 @@ history see `git log -- charts/lunar/`.
   boot migration and adds the schema assertion). Older hub images are
   incompatible with this chart version (the migrate binary is absent, and a
   matching hub image won't self-migrate).
+
 ## [2.4.1] - 2026-06-24
 
 ### Changed

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: "A Helm chart for Earthly Lunar \U0001F319"
 type: application
-version: 2.8.1
+version: 2.9.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -78,6 +78,12 @@ spec:
               value: {{ .db.waitSecs | quote }}
             - name: HUB_DB_CONNECTION_OPTIONS
               value: {{ .db.connectionOptions | quote }}
+            - name: HUB_DB_MAX_OPEN_CONNS
+              value: {{ .db.maxOpenConns | quote }}
+            - name: HUB_DB_MAX_POOL_CONNS
+              value: {{ .db.maxPoolConns | quote }}
+            - name: HUB_MAX_OPERATOR_POOL_SIZE
+              value: {{ .db.operatorPoolSize | quote }}
             - name: HUB_DB_MIGRATIONS_PATH
               value: "/usr/share/migrations"
             - name: HUB_GITHUB_WEBHOOK_SECRET

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -73,6 +73,16 @@ hub:
     # Also consumed by the operator (OPERATOR_DB_CONNECTION_OPTIONS); both
     # components connect to the same DB so they share this value.
     connectionOptions: "sslmode=require"
+    # Per-replica Postgres connection budget. Total connections to Postgres ≈
+    # replicaCount × (maxOpenConns + maxPoolConns + operatorPoolSize). The River
+    # queue shares the pgxpool (maxPoolConns). Defaults (20/20/5 = ~45/replica)
+    # are an educated guess sized so a small HA deploy (≈3 replicas → ~135)
+    # stays well under a typical Postgres max_connections with headroom for
+    # the migrate Job, psql, and superuser-reserved slots. Tune against your
+    # Postgres max_connections (and consider a connection pooler) for larger N.
+    maxOpenConns: 20      # HUB_DB_MAX_OPEN_CONNS (database/sql store handle)
+    maxPoolConns: 20      # HUB_DB_MAX_POOL_CONNS (pgxpool, shared by River)
+    operatorPoolSize: 5   # HUB_MAX_OPERATOR_POOL_SIZE (operator_queue pool)
   github:
     baseUrl: ""
     # Single-App config. Use this for single-tenant deployments where the

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -74,14 +74,20 @@ hub:
     # components connect to the same DB so they share this value.
     connectionOptions: "sslmode=require"
     # Per-replica Postgres connection budget. Total connections to Postgres ≈
-    # replicaCount × (maxOpenConns + maxPoolConns + operatorPoolSize). The River
-    # queue shares the pgxpool (maxPoolConns). Defaults (20/20/5 = ~45/replica)
-    # are an educated guess sized so a small HA deploy (≈3 replicas → ~135)
-    # stays well under a typical Postgres max_connections with headroom for
-    # the migrate Job, psql, and superuser-reserved slots. Tune against your
-    # Postgres max_connections (and consider a connection pooler) for larger N.
-    maxOpenConns: 20      # HUB_DB_MAX_OPEN_CONNS (database/sql store handle)
-    maxPoolConns: 20      # HUB_DB_MAX_POOL_CONNS (pgxpool, shared by River)
+    # replicaCount × (maxOpenConns + maxPoolConns + operatorPoolSize).
+    #
+    # Defaults match the hub's built-in values (40/40/5 ≈ 85/replica), so a
+    # single-replica install is UNCHANGED — no pool regression out of the box.
+    #
+    # For multi-replica (HA) deploys, LOWER maxOpenConns/maxPoolConns so the
+    # total fits your Postgres max_connections (leave headroom for the migrate
+    # Job, psql, and superuser-reserved slots), and consider a connection pooler
+    # for larger N. Keep maxPoolConns >= your peak concurrent River workers (the
+    # sum of hub.maxWorkers.*) — the pgxpool is shared by every queue plus the
+    # pgx stores, so a pool below that serializes store queries under load
+    # (pgxpool queues acquisition; it won't deadlock). See the HA runbook.
+    maxOpenConns: 40      # HUB_DB_MAX_OPEN_CONNS (database/sql store handle)
+    maxPoolConns: 40      # HUB_DB_MAX_POOL_CONNS (pgxpool, shared by River)
     operatorPoolSize: 5   # HUB_MAX_OPERATOR_POOL_SIZE (operator_queue pool)
   github:
     baseUrl: ""


### PR DESCRIPTION
## Summary

Right-sizes the hub's Postgres connection budget for multi-replica (HA) operation and makes it tunable (R9 / ENG-1033). Today each replica opens ~85 connections (`MaxOpenConns 40` + `MaxPoolConns 40` + operator pool `5`; River shares the pgxpool), which multiplies past a typical `max_connections` at N=3–5.

## Changes

- Expose the three pool knobs as chart values: `hub.db.maxOpenConns`, `hub.db.maxPoolConns`, `hub.db.operatorPoolSize` → `HUB_DB_MAX_OPEN_CONNS` / `HUB_DB_MAX_POOL_CONNS` / `HUB_MAX_OPERATOR_POOL_SIZE`.
- Lower the per-replica default to **`20/20/5` (~45)** so a small HA deploy (~3 replicas → ~135 connections) fits a typical Postgres `max_connections` with headroom for the migrate Job, psql, and reserved slots. A single hub at 45 is still ample.

## Educated guess — refine later

The `20/20/5` numbers are a deliberate **educated guess** (per the ask). Exact sizing should be set against the deployed Postgres `max_connections` and target replica count, and we may front Postgres with a pooler (PgBouncer/RDS Proxy) for larger N — both deferred. Total ≈ `replicaCount × (maxOpenConns + maxPoolConns + operatorPoolSize)`.

## Notes

- **Chart 2.7.0**, sequences after 2.6.0 (#65) and 2.5.0 (#64). Reconcile the version if merge order differs.
- Render-verified (env shows 20/20/5) + `helm lint` clean.
