### PR TITLE
[ENG-1034][ENG-1035] chart: readinessProbe -> /ready (DB/drain-aware)

### DIFF
--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,6 +9,27 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
+## [2.8.0] - 2026-06-29
+
+### Changed
+
+- **Readiness probe now uses `/ready`** (was `/health`). The hub's `/ready`
+  reports `503` while draining or when Postgres is unreachable, so a draining
+  or DB-broken replica is taken out of rotation; `livenessProbe` stays on
+  `/health` (always 200, DB-independent) so a shared-DB blip can't restart-loop
+  the fleet. Requires a hub image with the `/ready` endpoint (lunar #1979).
+
+### Notes
+
+- On AWS ALB, also point the target-group health check at `/ready` via ingress
+  annotations (`alb.ingress.kubernetes.io/healthcheck-path: /ready`,
+  `healthcheck-port: "8002"`) — see `values.yaml`.
+- Drain on shutdown is handled in the hub (`HUB_DRAIN_DELAY`, flips `/ready` to
+  503 on SIGTERM before stopping); no chart `preStop` is needed.
+
+> Note: sequences after 2.7.0 (#66) / 2.6.0 (#65) / 2.5.0 (#64). Reconcile the
+> version if merge order differs.
+
 ## [2.4.1] - 2026-06-24
 
 ### Changed

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: "A Helm chart for Earthly Lunar \U0001F319"
 type: application
-version: 2.4.1
+version: 2.8.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -201,7 +201,10 @@ spec:
           {{- with .Values.hub.readinessProbe }}
           readinessProbe:
             httpGet:
-              path: /health
+              # Readiness is DB-aware and drain-aware (503 while draining or if
+              # Postgres is unreachable). Liveness stays on /health (always 200,
+              # DB-independent) so a shared-DB blip can't restart-loop the fleet.
+              path: /ready
               port: hub-health
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -257,6 +257,11 @@ hub:
     # unless overridden inside api.* / webhooks.* below.
     className: ""
     tls: []
+    # On AWS ALB, point the target-group health check at the hub's DB/drain-aware
+    # readiness endpoint so the ALB stops routing to a draining or DB-broken
+    # replica (the k8s readinessProbe already uses /ready):
+    #   alb.ingress.kubernetes.io/healthcheck-path: /ready
+    #   alb.ingress.kubernetes.io/healthcheck-port: "8002"
     annotations: {}
     # API ingress: gRPC + /logs. Used by lunar CLI, CI agents, and the
     # operator. Renders TWO Ingress resources (api-grpc + api-http) sharing


### PR DESCRIPTION
## Summary

Chart companion to lunar #1979 — wires the hub's new readiness/drain (R3 / ENG-1034 + R5 / ENG-1035) into the deploy.

## Changes
- **`readinessProbe` → `/ready`** (was `/health`). `/ready` is DB- and drain-aware (503 while draining or if Postgres is unreachable), so a draining or DB-broken replica leaves the Service rotation. **`livenessProbe` stays `/health`** (always 200, DB-independent) so a shared-DB blip can't restart-loop the fleet.
- **values doc**: on AWS ALB, point the target-group health check at `/ready` via ingress annotations (`alb.ingress.kubernetes.io/healthcheck-path: /ready`, `healthcheck-port: "8002"`).

## Notes
- **No `preStop`**: drain is handled in the hub (`HUB_DRAIN_DELAY` flips `/ready`→503 on SIGTERM, then waits, then shuts down). A `preStop` sleep without a readiness flip would just keep routing traffic, so it's not added.
- **Requires** a hub image with the `/ready` endpoint (lunar #1979) — deploy together.
- **Chart 2.8.0**, sequences after #66 / #65 / #64. Reconcile the version if merge order differs.
