### PR TITLE
[ENG-1032] chart: expose + default gRPC MaxConnectionAge for HA (R7)

### DIFF
--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,6 +9,24 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
+## [2.8.0] - 2026-07-01
+
+### Added
+
+- **gRPC connection cycling for HA (R7).** New `hub.grpc.maxConnectionAge` and
+  `hub.grpc.maxConnectionAgeGrace` (defaults `30m` / `10m`) render to
+  `HUB_GRPC_MAX_CONNECTION_AGE` / `HUB_GRPC_MAX_CONNECTION_AGE_GRACE`. Bounding
+  connection age makes long-lived HTTP/2 clients periodically reconnect, so they
+  redistribute across hub replicas as the fleet scales and drop off a draining
+  replica during a rollout instead of pinning to the one they first reached. The
+  grace default (`10m`) exceeds the hub's 600s idle-stream timeout so a normal
+  stream (e.g. `PullManifest`) completes inside the grace window rather than
+  being cut. Requires a hub image with the knobs (earthly/lunar#1967); older
+  images ignore the env vars. Set both to `0` to disable (single-instance).
+
+> Note: additive; enabling by default is safe (clients transparently re-resolve
+> on GOAWAY).
+
 ## [2.7.0] - 2026-07-01
 
 ### Fixed
@@ -66,7 +84,6 @@ history see `git log -- charts/lunar/`.
   boot migration and adds the schema assertion). Older hub images are
   incompatible with this chart version (the migrate binary is absent, and a
   matching hub image won't self-migrate).
-
 ## [2.4.1] - 2026-06-24
 
 ### Changed

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: "A Helm chart for Earthly Lunar \U0001F319"
 type: application
-version: 2.7.0
+version: 2.8.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -167,6 +167,10 @@ spec:
               value: {{ .maxWorkers.cronCollect | quote }}
             - name: HUB_MAX_WORKERS_CATALOGER
               value: {{ .maxWorkers.cataloger | quote }}
+            - name: HUB_GRPC_MAX_CONNECTION_AGE
+              value: {{ .grpc.maxConnectionAge | quote }}
+            - name: HUB_GRPC_MAX_CONNECTION_AGE_GRACE
+              value: {{ .grpc.maxConnectionAgeGrace | quote }}
             {{- with .extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -159,6 +159,17 @@ hub:
     policy: 20
     cronCollect: 5
     cataloger: 1
+  # gRPC server connection-age limits (Go duration strings). Bounding a
+  # connection's lifetime makes long-lived HTTP/2 clients periodically
+  # reconnect, so they rebalance across hub replicas — and drop off a
+  # draining replica during a rollout — instead of pinning to whichever
+  # replica they first reached. maxConnectionAgeGrace should exceed the
+  # longest normal stream (the hub's idle-stream timeout is 600s, e.g.
+  # PullManifest) so streams finish inside the grace window rather than being
+  # cut. Set both to 0 to disable cycling (a single-instance hub needs none).
+  grpc:
+    maxConnectionAge: 30m
+    maxConnectionAgeGrace: 10m
   # S3-compatible object storage for script logs and resource archives.
   # The buckets must exist and be writable by the hub's AWS credentials.
   # AWS credentials themselves are intentionally out of scope for this


### PR DESCRIPTION
## Summary

The chart half of R7 (ENG-1032). earthly/lunar#1967 added `HUB_GRPC_MAX_CONNECTION_AGE` / `_GRACE` but defaults them to `0` (**off**), so on its own it doesn't cycle connections. This exposes both as chart values and ships sane HA defaults, which is what actually activates R7.

## Context

Long-lived HTTP/2 gRPC connections pin a client to whichever replica it first reached, so load doesn't rebalance as replicas are added and clients stay bound to a draining replica through a rollout. Bounding connection age triggers a periodic GOAWAY; clients transparently re-resolve and redistribute.

- New `hub.grpc.maxConnectionAge` (`30m`) and `hub.grpc.maxConnectionAgeGrace` (`10m`), wired into the hub Deployment env.
- Grace `10m` exceeds the hub's 600s idle-stream timeout (e.g. `PullManifest`) so a normal stream finishes inside the grace window instead of being cut. Set both to `0` to disable (single-instance).

## Call-outs

- **Enabled by default.** Additive and transparent (clients re-resolve on GOAWAY), but it is a behavior change for all chart consumers — deliberate, since activating R7 is the point.
- Requires a hub image carrying the knobs (earthly/lunar#1967); older images simply ignore the env vars.
- Chart `2.5.0`. Version sequences after 2.4.1 — reconcile if another chart PR lands a 2.5.0 first.
- Verified: `helm lint` clean; renders `30m`/`10m` by default and `0` when overridden.