### PR TITLE
[ENG-1037] chart: render hub.extraEnv on the migrate Job (fix fresh-DB SQL-API)

### DIFF
--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,6 +9,23 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
+## [2.6.0] - 2026-07-01
+
+### Fixed
+
+- **Migrate Job now renders `hub.extraEnv`** (parity with the hub Deployment). The
+  chart supplies SQL-API credentials only through `hub.extraEnv` (there is no
+  dedicated `HUB_SQLAPI_*` value), and the 2.5.0 migrate Job omitted it — so on a
+  **fresh** database the `01_sqlapi/user.sql` migration created the `sqlapi_user`
+  role **without** a password, leaving the SQL API unable to authenticate. This
+  only affected first/greenfield installs (an already-migrated DB doesn't re-run
+  the migration), which is why it wasn't caught by an in-place upgrade. Any env you
+  already set in `hub.extraEnv` for the hub (e.g. `HUB_SQLAPI_PASSWORD`) now also
+  reaches the migrator.
+
+> Note: version sequences after 2.5.0 — reconcile if another chart PR lands a 2.6.0
+> first.
+
 ## [2.5.0] - 2026-06-26
 
 ### Changed

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: "A Helm chart for Earthly Lunar \U0001F319"
 type: application
-version: 2.5.0
+version: 2.6.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/hub-migrate-job.yaml
+++ b/charts/lunar/templates/hub-migrate-job.yaml
@@ -94,6 +94,16 @@ spec:
             # Best-effort in the binary — falls back to stderr if absent.
             - name: HUB_LICENCE_FILE
               value: {{ .licence.filePath | quote }}
+            # Same extraEnv as the hub Deployment. Required so the migrator
+            # sees HUB_SQLAPI_PASSWORD (the chart supplies SQL-API creds only
+            # via extraEnv): 01_sqlapi/user.sql creates the sqlapi_user role,
+            # and on a *fresh* database (greenfield install) that role must be
+            # created WITH its password or the SQL API can't authenticate.
+            # (An already-migrated DB — e.g. an upgrade — doesn't re-run it, so
+            # this only bites first installs; it went unnoticed until then.)
+            {{- with .extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           volumeMounts:
             - name: hub-licence


### PR DESCRIPTION
## Summary

The 2.5.0 migrate Job (charts#64) doesn't render `hub.extraEnv`, so on a **fresh** database the `sqlapi_user` role is created **without a password** and the SQL API can't authenticate. Fix: render `hub.extraEnv` on the migrate Job, matching the hub Deployment.

## Root cause

The chart supplies SQL-API credentials only through `hub.extraEnv` — there is no dedicated `HUB_SQLAPI_*` chart value. `lunar-hub-migrate` runs `hub/migrations/01_sqlapi/user.sql`, which creates/grants `sqlapi_user` using `HUB_SQLAPI_USER_NAME` (defaults to `sqlapi_user`) and `HUB_SQLAPI_PASSWORD` (no default). The SQL guards an empty password (`CREATE ROLE … LOGIN{{ if .SQLAPIPassword }} PASSWORD …{{ end }}`), so the migration *succeeds* but the role ends up passwordless — and with managed/scram host auth the hub then can't connect as it.

It only bites **greenfield** installs: an already-migrated DB doesn't re-run `01_sqlapi/user.sql`, so an in-place upgrade never surfaces it (this is why the Cronos R6 validation, on an already-migrated schema, passed).

## Fix

Render `hub.extraEnv` in `hub-migrate-job.yaml` (one block, same as the hub Deployment). Anything already set in `hub.extraEnv` for the hub — notably `HUB_SQLAPI_PASSWORD` — now reaches the migrator too. Chart `2.6.0`.

Found while wiring e2e/localdev onto the real chart (ENG-1094); that work depends on this release. Verified: `helm lint` clean; the rendered migrate Job now includes the `extraEnv` entries.