### PR TITLE
[ENG-1037] chart: drop serviceAccountName from the migrate Job (fix fresh-install)

### DIFF
--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,6 +9,22 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
+## [2.7.0] - 2026-07-01
+
+### Fixed
+
+- **Migrate Job no longer sets `serviceAccountName`.** As a pre-install hook the
+  Job runs *before* the chart's ServiceAccount is created, so referencing it made
+  the Job unschedulable on a **fresh** install (`serviceaccount "…" not found` →
+  the Job burns `activeDeadlineSeconds` → `DeadlineExceeded` → `helm install`
+  fails). The migrator makes no Kubernetes API calls (it only talks to Postgres),
+  so it now uses the namespace `default` SA. Only affected first/greenfield
+  installs — an upgrade already had the SA from the prior release. Image pulls are
+  unaffected (`imagePullSecrets` is on the pod spec).
+
+> Note: version sequences after 2.6.0 — reconcile if another chart PR lands a
+> 2.7.0 first.
+
 ## [2.6.0] - 2026-07-01
 
 ### Fixed

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: "A Helm chart for Earthly Lunar \U0001F319"
 type: application
-version: 2.6.0
+version: 2.7.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/hub-migrate-job.yaml
+++ b/charts/lunar/templates/hub-migrate-job.yaml
@@ -35,7 +35,12 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "lunar.serviceAccountName" . }}
+      # No serviceAccountName: the migrator makes no Kubernetes API calls (it
+      # only connects to Postgres), so it uses the namespace's default SA. This
+      # is deliberate — as a pre-install hook the Job runs BEFORE the chart's
+      # ServiceAccount is created, so referencing it would fail to schedule on a
+      # fresh install ("serviceaccount not found" → DeadlineExceeded). Image
+      # pulls are unaffected (imagePullSecrets is on the pod spec above).
       {{- with .Values.hub.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Summary

On a **fresh** install the pre-rollout migrate Job never schedules and `helm install` fails:

```
Error: failed pre-install: job lunar-hub-migrate failed: DeadlineExceeded
Warning FailedCreate job/lunar-hub-migrate:
  pods "lunar-hub-migrate-" is forbidden: error looking up service account
  default/<release>: serviceaccount "<release>" not found
```

## Root cause

The migrate Job is a Helm `pre-install,pre-upgrade` hook that sets `serviceAccountName: {{ include "lunar.serviceAccountName" . }}`. The chart's ServiceAccount is a *normal* resource, so Helm creates it only in the main install phase — **after** pre-install hooks. On a fresh install the SA doesn't exist yet → the Job's pod can't be created → it burns `activeDeadlineSeconds` (600s) → `DeadlineExceeded` → the pre-install hook fails.

Only bites greenfield installs (localdev/e2e/first prod install). An upgrade already has the SA from the prior release, which is why the Cronos R6 validation (an in-place upgrade) passed.

## Fix

Drop `serviceAccountName` from the Job — the migrator makes **no Kubernetes API calls** (it only connects to Postgres), so the namespace `default` SA is correct. Image pulls are unaffected: `imagePullSecrets` is on the pod spec, not the SA. Chart `2.7.0`.

Caught by the ENG-1094 e2e run (fresh kind DB). Verified: `helm lint` clean; rendered migrate Job has no `serviceAccountName`. ENG-1094 (#1997) re-pins to 2.7.0 once released.