### PR TITLE
[ENG-1032] chart: correct gRPC grace comment (charts#69 nit)

### DIFF
--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,6 +9,20 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
+## [2.8.1] - 2026-07-01
+
+### Docs
+
+- Correct the `hub.grpc.maxConnectionAgeGrace` guidance. The prior note claimed
+  grace must exceed a 600s idle-stream timeout so streams finish inside the
+  window — but `PullManifest` (the one long server-stream) is kept open by a 30s
+  heartbeat and can outlast any idle timeout, so 600s was never the bound. It's a
+  non-issue in practice: `PullManifest` is only invoked by the one-shot `lunar`
+  CLI on a freshly-dialed connection (age 0 → full runway), and the long-lived
+  fetch client uses unary calls. Comment-only; no behavior change. (charts#69 nit)
+
+> Note: patch on 2.8.0 — reconcile if another chart PR lands a 2.8.1 first.
+
 ## [2.8.0] - 2026-07-01
 
 ### Added

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: "A Helm chart for Earthly Lunar \U0001F319"
 type: application
-version: 2.8.0
+version: 2.8.1
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -163,10 +163,14 @@ hub:
   # connection's lifetime makes long-lived HTTP/2 clients periodically
   # reconnect, so they rebalance across hub replicas — and drop off a
   # draining replica during a rollout — instead of pinning to whichever
-  # replica they first reached. maxConnectionAgeGrace should exceed the
-  # longest normal stream (the hub's idle-stream timeout is 600s, e.g.
-  # PullManifest) so streams finish inside the grace window rather than being
-  # cut. Set both to 0 to disable cycling (a single-instance hub needs none).
+  # replica they first reached. maxConnectionAgeGrace is the window in which
+  # in-flight RPCs finish after the age-GOAWAY before the connection is
+  # force-closed. Nearly all hub RPCs are short unary calls; the one long
+  # server-stream (PullManifest, held open by a 30s heartbeat during cataloger
+  # waits, so it can outlast any idle timeout) is only ever invoked by the
+  # one-shot `lunar` CLI on a freshly-dialed connection — age starts at 0, so it
+  # gets the full age+grace runway and cycling never cuts it mid-flight. Set
+  # both to 0 to disable cycling (a single-instance hub needs none).
   grpc:
     maxConnectionAge: 30m
     maxConnectionAgeGrace: 10m


### PR DESCRIPTION
## Summary

Follow-up to the non-blocking nit on charts#69 (@me-bender): the `hub.grpc.maxConnectionAgeGrace` comment claimed grace must exceed a "600s idle-stream timeout" so streams finish inside the window. That premise is wrong, and the concern it implied doesn't arise. Comment-only — no behavior change. Chart `2.8.1` (patch — comment-only).

## Why the old comment was wrong

`PullManifest` (the one long server-stream) is held open by a 30s heartbeat during cataloger waits (`hub/manifest.go`), specifically to outlast idle timeouts — so it's bounded by cataloger duration, not 600s.

## Why it's a non-issue

`PullManifest` is only invoked by the **one-shot `lunar` CLI** (`cmd/lunar/hub.go`) on a **freshly-dialed** connection, so age starts at 0 and it always has the full `maxConnectionAge + grace` runway — cycling never cuts it mid-flight. The **long-lived** fetch client (`snippets/fetch/periodic.go`) uses **unary** `CurrentVersion` (already retried on `Unavailable`), not the stream. So no client streams `PullManifest` on a reused/aged connection.

Corrected comment reframes grace as "the window for in-flight RPCs to finish after the age-GOAWAY" and explains the `PullManifest` fresh-dial reasoning.