### PR TITLE
chart: add Deployment-level annotations for hub, grafana, operator

### DIFF
--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,6 +9,17 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
+## [2.10.0] - 2026-07-02
+
+### Added
+
+- **Deployment-level `annotations`.** New `hub.annotations`, `grafana.annotations`,
+  and `operator.annotations` render onto each workload's Deployment `metadata`
+  (distinct from the existing `podAnnotations`, which apply to the pod template).
+  `hub.annotations` and `grafana.annotations` already existed as chart values but
+  were never wired into a template; `operator.annotations` is new. Empty by
+  default — no behavior change for existing installs.
+
 ## [2.9.0] - 2026-07-01
 
 ### Added

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: "A Helm chart for Earthly Lunar \U0001F319"
 type: application
-version: 2.9.0
+version: 2.10.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/grafana-deployment.yaml
+++ b/charts/lunar/templates/grafana-deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ include "lunar.fullname" . }}-grafana
   labels:
     {{- include "lunar.labels" . | nindent 4 }}
+  {{- with .Values.grafana.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -10,6 +10,10 @@ metadata:
   name: {{ include "lunar.fullname" . }}-hub
   labels:
     {{- include "lunar.labels" . | nindent 4 }}
+  {{- with .Values.hub.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   {{- if .Values.hub.persistence.enabled }}

--- a/charts/lunar/templates/operator-deployment.yaml
+++ b/charts/lunar/templates/operator-deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "lunar.fullname" . }}-operator
   labels:
     {{- include "lunar.labels" . | nindent 4 }}
+  {{- with .Values.operator.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -431,6 +431,7 @@ operator:
   scriptPodPriorityClassName: ""
   extraEnv: []
   resources: {}
+  annotations: {}
   podAnnotations: {}
   podLabels: {}
   podSecurityContext: {}


### PR DESCRIPTION
## Summary
- `hub.annotations` and `grafana.annotations` already existed as chart values but were never rendered onto any template — wired them onto their Deployment's `metadata.annotations`.
- Added `operator.annotations` (new value) and wired it the same way.
- These are distinct from the existing `podAnnotations` (which apply to the pod template, not the Deployment object itself).
- Bumped chart to 2.10.0 and added a CHANGELOG entry.

## Test plan
- [x] `helm lint charts/lunar` — passes (pre-existing required-value failures only, unrelated to this change).
- [x] `helm template lunar . --output-dir render.tmp --values values.yaml --values test_values.yaml` with:
  ```yaml
  hub:
    annotations:
      foo: bar
  operator:
    annotations:
      foo: bar
  grafana:
    annotations:
      foo: bar
  ```
  confirmed `metadata.annotations: {foo: bar}` renders on all three Deployments (`grafana-deployment.yaml`, `hub-deployment.yaml`, `operator-deployment.yaml`).
- [x] Confirmed default (no annotations set) omits the `annotations:` block entirely — no behavior change for existing installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)