### PR TITLE
Properly wire up labels

### DIFF
--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,6 +9,19 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
+## [2.11.0] - 2026-07-02
+
+### Added
+
+- **Deployment-level `labels`.** New `hub.labels`, `grafana.labels`, and
+  `operator.labels` merge onto each workload's Deployment `metadata.labels`,
+  alongside the chart's standard `lunar.labels` (custom keys win on collision).
+  Distinct from the existing `podLabels`, which apply to the pod template.
+  `hub.labels` and `grafana.labels` already existed as chart values but were
+  never wired into a template; `operator.labels` is new. Empty by default —
+  no behavior change for existing installs. Companion to the `annotations`
+  values wired in 2.10.0.
+
 ## [2.10.0] - 2026-07-02
 
 ### Added

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: "A Helm chart for Earthly Lunar \U0001F319"
 type: application
-version: 2.10.0
+version: 2.11.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/grafana-deployment.yaml
+++ b/charts/lunar/templates/grafana-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "lunar.fullname" . }}-grafana
   labels:
     {{- include "lunar.labels" . | nindent 4 }}
+    {{- with .Values.grafana.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.grafana.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -10,6 +10,9 @@ metadata:
   name: {{ include "lunar.fullname" . }}-hub
   labels:
     {{- include "lunar.labels" . | nindent 4 }}
+    {{- with .Values.hub.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.hub.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/lunar/templates/operator-deployment.yaml
+++ b/charts/lunar/templates/operator-deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "lunar.fullname" . }}-operator
   labels:
     {{- include "lunar.labels" . | nindent 4 }}
+    {{- with .Values.operator.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.operator.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -431,6 +431,7 @@ operator:
   scriptPodPriorityClassName: ""
   extraEnv: []
   resources: {}
+  labels: {}
   annotations: {}
   podAnnotations: {}
   podLabels: {}


### PR DESCRIPTION
## Summary
Wire operator-supplied `labels` onto the hub, operator, and grafana Deployments —
the label-shaped twin of the `annotations` plumbing added in #73.
- `hub.labels`, `grafana.labels`, and `operator.labels` now merge onto each
  workload's Deployment `metadata.labels`, alongside the chart's standard
  `lunar.labels` (custom keys win on collision).
- `hub.labels` and `grafana.labels` already existed as chart values but were
  never rendered into any template — setting them did nothing. `operator.labels`
  is new (added for parity).
- Distinct from the existing `podLabels`, which apply to the pod template
  (`spec.template.metadata.labels`), not the Deployment object itself.
- Bumps the chart to 2.11.0 with a CHANGELOG entry.
## Why
Operators installing the chart need a hook to put their own labels on the
workload objects — the chart's `lunar.labels` are fixed identity labels and
can't be extended without editing chart source. Real drivers:
- **Admission policy.** Clusters running Gatekeeper/Kyverno commonly require
  labels like `team` / `cost-center` on every Deployment — without a hook the
  chart won't install there.
- **Cost & ownership tooling.** Kubecost, FinOps rollups, `kubectl get deploy -l`,
  backup/GitOps selectors all key off operator-defined labels.
Previously the only escape hatches were a Helm post-renderer or hand-editing
after apply (which GitOps reverts). This closes that gap.
> Found while reviewing the missing annotations plumbing in #73 — the `labels`
> values were sitting right next to `annotations` with the exact same
> declared-but-never-wired bug, so this finishes the set.