### PR TITLE
hub: point readinessProbe at /ready (ENG-1120)

### DIFF
--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,6 +9,18 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
+## [2.13.0] - 2026-07-03
+
+### Changed
+
+- **hub**: the readiness probe now targets `/ready` (was `/health`) with
+  `failureThreshold: 1`, so the pod reports not-ready as soon as the hub begins
+  graceful shutdown (Hub HA R4, ENG-1120) and k8s deregisters it from the
+  Service before it drains. Liveness still targets `/health` (process-only, so a
+  draining or DB-blipped pod is never restarted). Requires a hub image that
+  serves `/ready` (lunar-hub with ENG-1120); `terminationGracePeriodSeconds` (60)
+  already covers the hub's readiness delay + shutdown timeout.
+
 ## [2.12.0] - 2026-07-02
 
 ### Changed

--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -23,6 +23,10 @@ history see `git log -- charts/lunar/`.
   graceful shutdown and k8s deregisters it. Liveness still targets `/health`
   (process-only, so a draining or DB-blipped pod is never restarted). Requires a
   hub image that serves `/ready` (lunar-hub with ENG-1120).
+- **images**: default image tags (hub, operator, init, sidecar, grafana) bumped
+  to `2.6.0` — the first hub release that serves `/ready` — in lockstep with the
+  readiness-probe change above, so the chart default never points at an image
+  that 404s the probe.
 
 ## [2.12.0] - 2026-07-02
 

--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -13,13 +13,16 @@ history see `git log -- charts/lunar/`.
 
 ### Changed
 
+- **hub**: added a `preStop` hook (`hub.preStopSleepSeconds`, default 10s) that
+  sleeps before SIGTERM, giving k8s time to deregister the pod from the Service
+  so new requests stop arriving before the hub drains (graceful shutdown, Hub HA
+  R4, ENG-1120). `terminationGracePeriodSeconds` (60) covers this plus the hub's
+  shutdown budget (`HUB_SHUTDOWN_TIMEOUT`, 45s).
 - **hub**: the readiness probe now targets `/ready` (was `/health`) with
   `failureThreshold: 1`, so the pod reports not-ready as soon as the hub begins
-  graceful shutdown (Hub HA R4, ENG-1120) and k8s deregisters it from the
-  Service before it drains. Liveness still targets `/health` (process-only, so a
-  draining or DB-blipped pod is never restarted). Requires a hub image that
-  serves `/ready` (lunar-hub with ENG-1120); `terminationGracePeriodSeconds` (60)
-  already covers the hub's readiness delay + shutdown timeout.
+  graceful shutdown and k8s deregisters it. Liveness still targets `/health`
+  (process-only, so a draining or DB-blipped pod is never restarted). Requires a
+  hub image that serves `/ready` (lunar-hub with ENG-1120).
 
 ## [2.12.0] - 2026-07-02
 

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: "A Helm chart for Earthly Lunar \U0001F319"
 type: application
-version: 2.12.0
+version: 2.13.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -212,7 +212,7 @@ spec:
           {{- with .Values.hub.readinessProbe }}
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: hub-health
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}

--- a/charts/lunar/templates/hub-deployment.yaml
+++ b/charts/lunar/templates/hub-deployment.yaml
@@ -219,6 +219,16 @@ spec:
             failureThreshold: {{ .failureThreshold }}
           {{- end }}
           {{- end }}
+          {{- if gt (int .Values.hub.preStopSleepSeconds) 0 }}
+          # Sleep before SIGTERM so k8s deregisters this pod from the Service
+          # (endpoint removal on deletion) before the hub starts draining —
+          # graceful shutdown, R4. Must leave room under
+          # terminationGracePeriodSeconds for the hub's own drain.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "{{ .Values.hub.preStopSleepSeconds }}"]
+          {{- end }}
           ports:
             - name: hub-grpc
               containerPort: 8000

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -354,7 +354,7 @@ hub:
     enabled: true
     initialDelaySeconds: 0
     periodSeconds: 5
-    failureThreshold: 3
+    failureThreshold: 1
   livenessProbe:
     enabled: true
     initialDelaySeconds: 0

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -286,7 +286,7 @@ hub:
   image:
     repository: "ghcr.io/earthly/lunar-hub"
     pullPolicy: IfNotPresent
-    tag: "2.5.0"
+    tag: "2.6.0"
   service:
     type: ClusterIP
     ports:
@@ -380,15 +380,15 @@ operator:
   image:
     repository: "ghcr.io/earthly/lunar-snippet-operator"
     pullPolicy: IfNotPresent
-    tag: "2.5.0"
+    tag: "2.6.0"
   initImage:
     repository: "ghcr.io/earthly/lunar-snippet-init"
     pullPolicy: IfNotPresent
-    tag: "2.5.0"
+    tag: "2.6.0"
   sidecarImage:
     repository: "ghcr.io/earthly/lunar-snippet-sidecar"
     pullPolicy: IfNotPresent
-    tag: "2.5.0"
+    tag: "2.6.0"
   # Namespace where script pods are created. Defaults to the release namespace.
   # If set, the namespace must already exist — the chart will not create it.
   scriptNamespace: ""
@@ -497,7 +497,7 @@ grafana:
   image:
     repository: "ghcr.io/earthly/lunar-grafana"
     pullPolicy: IfNotPresent
-    tag: "2.5.0"
+    tag: "2.6.0"
   service:
     type: ClusterIP
     port: 80

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -43,9 +43,13 @@ hub:
   # S3), so it runs safely at replicaCount > 1 in HA (multi-replica) mode. See
   # the HA operations runbook.
   replicaCount: 1
-  # Grace period for the hub to drain on SIGTERM; must be >= the hub's shutdown
-  # budget.
+  # Grace period for the hub to drain on SIGTERM; must be >= preStopSleepSeconds
+  # plus the hub's shutdown budget (HUB_SHUTDOWN_TIMEOUT, default 45s).
   terminationGracePeriodSeconds: 60
+  # Seconds the container sleeps in its preStop hook, before SIGTERM, giving k8s
+  # time to deregister this pod from the Service so new requests stop arriving
+  # before the hub drains (graceful shutdown, R4). Set 0 to disable.
+  preStopSleepSeconds: 10
   # PodDisruptionBudget for the hub. Off by default — a PDB on a single replica
   # can block voluntary node drains. Enable for multi-replica deploys. Set
   # exactly one of maxUnavailable / minAvailable — the chart fails fast at


### PR DESCRIPTION
## Summary

Companion to earthly/lunar#2011 (ENG-1120), completing R4 graceful shutdown at the chart layer (chart **2.13.0**):

- **`preStop` hook** (`hub.preStopSleepSeconds`, default `10s`): sleeps before SIGTERM so k8s deregisters the pod from the Service *before* the hub drains. Set `0` to disable.
- **`readinessProbe`** `/health` → **`/ready`**, `failureThreshold: 1` (the endpoint is a deterministic in-memory flag, so react on the first not-ready). **Liveness stays `/health`** (process-only).

## Ordering / compatibility

Requires a hub image that serves `/ready` (lunar-hub with ENG-1120). Don't bump a tenant to 2.13.0 until its hub image includes it — on an older image `/ready` 404s → the pod never goes Ready. Same lockstep discipline as the B1 chart↔hub coupling.

`terminationGracePeriodSeconds` (60) covers `preStopSleepSeconds` (10) + `HUB_SHUTDOWN_TIMEOUT` (45) = 55s.