### PR TITLE
[ENG-1054] chart: HA (N≥2) by default

### DIFF
--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: "A Helm chart for Earthly Lunar \U0001F319"
 type: application
-version: 2.13.0
+version: 2.14.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -40,9 +40,12 @@ hub:
   # GitHub would POST into the void.
   webhookURL: ""
   # Number of hub replicas. The hub is stateless (state lives in Postgres and
-  # S3), so it runs safely at replicaCount > 1 in HA (multi-replica) mode. See
-  # the HA operations runbook.
-  replicaCount: 1
+  # S3), so HA (multi-replica) is the recommended default. N=2 tolerates losing
+  # one pod; scale to 3 for more headroom. Set 1 for a minimal single-instance
+  # install (a config-only fallback — no schema/state change either way). NOTE:
+  # total Postgres connections scale with replicaCount — see db.maxPoolConns
+  # below and size max_connections accordingly. See the HA operations runbook.
+  replicaCount: 2
   # Grace period for the hub to drain on SIGTERM; must be >= preStopSleepSeconds
   # plus the hub's shutdown budget (HUB_SHUTDOWN_TIMEOUT, default 45s).
   terminationGracePeriodSeconds: 60
@@ -50,12 +53,14 @@ hub:
   # time to deregister this pod from the Service so new requests stop arriving
   # before the hub drains (graceful shutdown, R4). Set 0 to disable.
   preStopSleepSeconds: 10
-  # PodDisruptionBudget for the hub. Off by default — a PDB on a single replica
-  # can block voluntary node drains. Enable for multi-replica deploys. Set
-  # exactly one of maxUnavailable / minAvailable — the chart fails fast at
-  # render time if both are set (the API server rejects a PDB with both).
+  # PodDisruptionBudget for the hub. On by default to match the multi-replica
+  # default — it keeps a replica serving during voluntary node drains. Disable
+  # it if you set replicaCount: 1, since a PDB on a single replica can block
+  # voluntary node drains. Set exactly one of maxUnavailable / minAvailable —
+  # the chart fails fast at render time if both are set (the API server rejects
+  # a PDB with both).
   podDisruptionBudget:
-    enabled: false
+    enabled: true
     maxUnavailable: 1
     # minAvailable: 1
   # Extra pod topology-spread constraints for hub replicas. Empty is NOT
@@ -100,16 +105,21 @@ hub:
     # Per-replica Postgres connection budget. Total connections to Postgres ≈
     # replicaCount × (maxOpenConns + maxPoolConns + operatorPoolSize).
     #
-    # Defaults match the hub's built-in values (40/40/5 ≈ 85/replica), so a
-    # single-replica install is UNCHANGED — no pool regression out of the box.
+    # Defaults (40/40/5 ≈ 85/replica) match the hub's built-in values. With the
+    # default replicaCount: 2 that is a ceiling of ~170 connections, so size your
+    # Postgres max_connections >= replicaCount × 85 plus headroom for the migrate
+    # Job, psql, and superuser-reserved slots (~200 for the N=2 default, ~270 for
+    # N=3). Managed Postgres (RDS/Aurora/Cloud SQL) sizes well above this by
+    # default; a bare Postgres at max_connections=100 must be raised for HA.
     #
-    # For multi-replica (HA) deploys, LOWER maxOpenConns/maxPoolConns so the
-    # total fits your Postgres max_connections (leave headroom for the migrate
-    # Job, psql, and superuser-reserved slots), and consider a connection pooler
-    # for larger N. Keep maxPoolConns >= your peak concurrent River workers (the
-    # sum of hub.maxWorkers.*) — the pgxpool is shared by every queue plus the
-    # pgx stores, so a pool below that serializes store queries under load
-    # (pgxpool queues acquisition; it won't deadlock). See the HA runbook.
+    # Do NOT lower maxPoolConns below your peak concurrent River workers (the sum
+    # of hub.maxWorkers.*, currently 36) — the pgxpool is shared by every queue
+    # plus the pgx stores, so a smaller pool serializes store queries under load
+    # (pgxpool queues acquisition; it won't deadlock). To shrink the per-replica
+    # budget, reduce maxWorkers.* first, then maxPoolConns to match. A connection
+    # pooler helps only at large N — and a transaction-mode pooler breaks the
+    # hub's session advisory locks and LISTEN/NOTIFY, so it must not front them
+    # (use a direct connection for those). See the HA runbook.
     maxOpenConns: 40      # HUB_DB_MAX_OPEN_CONNS (database/sql store handle)
     maxPoolConns: 40      # HUB_DB_MAX_POOL_CONNS (pgxpool, shared by River)
     operatorPoolSize: 5   # HUB_MAX_OPERATOR_POOL_SIZE (operator_queue pool)


### PR DESCRIPTION
## Summary

Make multi-replica the default posture for the Lunar chart now that the Hub HA epic is validated end-to-end (B1, R1–R11 merged; load test and chaos both passed on the cronos N=3 soak). This is the "GA + recommend N≥2" step of ENG-1054.

## Changes

- `hub.replicaCount` **1 → 2** — N=2 tolerates losing one pod; scale to 3 for more headroom. `1` remains a config-only single-instance fallback (no schema/state change either way).
- `hub.podDisruptionBudget.enabled` **false → true** (`maxUnavailable: 1`), matching the multi-replica default.
- Chart **2.13.0 → 2.14.0** (image pins unchanged at 2.6.0).

## Connection budget — please note

Pools are **left at 40/40/5 on purpose.** `maxPoolConns` must stay ≥ the sum of `hub.maxWorkers.*` (currently **36**) or the shared pgxpool serializes store queries under load — so they can't be lowered without also cutting worker throughput. Consequently the N=2 default has a **~170-connection ceiling**, and the values comment now documents sizing `max_connections ≥ replicaCount × 85` (~200 for N=2, ~270 for N=3).

Managed Postgres (RDS/Aurora/Cloud SQL — the chart's assumed target, per the `sslmode=require` default) sizes well above this. A bare Postgres at the default `max_connections=100` must be raised before running HA. **Existing installs that upgrade without pinning `replicaCount` will go to N=2** — this is the intended "recommend N≥2" behavior, but it doubles the pod and connection footprint, so it belongs in the release notes.

## Follow-ups (not in this PR)

- Runbook + release-note copy recommending N≥2 and the `max_connections` requirement — ENG-1128.