### PR TITLE
[ENG-1136] chart: operator replicaCount + leader-election RBAC (multi-replica)

### DIFF
--- a/charts/lunar/CHANGELOG.md
+++ b/charts/lunar/CHANGELOG.md
@@ -9,6 +9,19 @@ History starts at 1.0.0 (the snippet→script rename and ghcr.io
 switchover); earlier 0.x versions had no production users. For 0.x
 history see `git log -- charts/lunar/`.
 
+## [2.16.0] - 2026-07-08
+
+### Added
+
+- `operator.replicaCount` (default `1`) — run the snippet operator at N≥2. Safe
+  at N>1 on an operator image with Manager leader election (lunar ENG-1136):
+  snippet execution stays active-active (River workers) while exactly one replica
+  runs the pod-GC reconciler via a leader-election `Lease`. On a pre-LE image, N>1
+  is still safe but runs N duplicate (idempotent) GC passes.
+- Leader-election RBAC on the operator `Role`: `coordination.k8s.io/leases` (the
+  `events` grant already existed). Required when `operator.replicaCount > 1` on
+  the leader-elected image.
+
 ## [2.15.0] - 2026-07-08
 
 ### Changed

--- a/charts/lunar/Chart.yaml
+++ b/charts/lunar/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lunar
 description: "A Helm chart for Earthly Lunar \U0001F319"
 type: application
-version: 2.15.0
+version: 2.16.0
 kubeVersion: ">=1.29.0-0"

--- a/charts/lunar/templates/operator-deployment.yaml
+++ b/charts/lunar/templates/operator-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.operator.replicaCount | default 1 }}
   selector:
     matchLabels:
       {{- include "lunar.selectorLabels" . | nindent 6 }}

--- a/charts/lunar/templates/operator-rbac.yaml
+++ b/charts/lunar/templates/operator-rbac.yaml
@@ -13,6 +13,12 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+  # Leader election for multi-replica operators (controller-runtime Manager LE).
+  # The Lease lives in OPERATOR_NAMESPACE, which is this Role's namespace
+  # (scriptNamespace); whichever replica holds it runs the pod-GC reconciler.
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/lunar/values.yaml
+++ b/charts/lunar/values.yaml
@@ -387,6 +387,14 @@ hub:
   tolerations: []
   affinity: {}
 operator:
+  # Number of operator replicas. Safe at N>1 on the leader-elected image (>= the
+  # release that adds operator Manager leader election): snippet execution stays
+  # active-active (River workers), while exactly one replica runs the pod-GC
+  # reconciler via the leader-election Lease (RBAC in operator-rbac.yaml). On a
+  # pre-LE image, N>1 is still safe but runs N duplicate (idempotent) GC passes.
+  # Operator Postgres connections scale with replicaCount. Keep at 1 unless you
+  # want operator failover / throughput.
+  replicaCount: 1
   image:
     repository: "ghcr.io/earthly/lunar-snippet-operator"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

Support running `lunar-snippet-operator` at **N≥2** (proposal earthly/plans#59). Companion to the lunar PR that enables Manager leader election in the operator (earthly/lunar#2041).

## Changes

- **`operator.replicaCount`** (default `1`) → operator Deployment `replicas`. Exposes the knob; default unchanged.
- **Leader-election RBAC**: add `coordination.k8s.io/leases` to the operator `Role` (the `events` grant already existed). The `Lease` lives in `OPERATOR_NAMESPACE`, which is this Role's namespace (`scriptNamespace`), so no new Role/namespace is needed.
- Chart **2.16.0** + CHANGELOG.

## Behavior

- **N=1 (default):** unchanged.
- **N>1 on the leader-elected operator image** (lunar ENG-1136 / #2041): snippet execution stays **active-active** (River workers, started outside the Manager), while exactly **one** replica runs the pod-GC reconciler via the Lease.
- **N>1 on a pre-LE image:** still safe (the GC delete is idempotent), just runs N duplicate no-op GC passes.

## Rollout / sequencing

Chart cuts a release on merge. Deploy the **LE-capable operator image first** (the release that includes #2041), then raise `operator.replicaCount`. Operator Postgres connections scale ×replicaCount — size accordingly.

Rendered clean against the localdev dev-values (default `replicas: 1`; `--set operator.replicaCount=3` → `3`; lease rule present).